### PR TITLE
Sync English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-# 🧠 StrataGate
+# StrataGate
 
-### Recent conversations stay verbatim. Older ones become an index. Answers wait for enough evidence.
+### Keep nearby conversations verbatim and distant ones as an index. Answer only when the evidence is sufficient.
 
 [![CI](https://github.com/diqierjia/StrataGate/actions/workflows/ci.yml/badge.svg)](https://github.com/diqierjia/StrataGate/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -12,84 +12,45 @@
 
 </div>
 
-StrataGate is a memory system for AI agents. It is built around two simple rules.
+StrataGate is a TypeScript memory kernel for long-running AI agents.
 
-## 🪶 1. Memory should get lighter with distance, not disappear
+It primarily addresses two problems:
 
-```text
-Just happened                                              Long ago
-exact words  →  readable transcript  →  key points  →  title + index
-     ↑                                                       ↓
-     └──────── open only the needed memory back to source ───┘
+- As a conversation grows, how can everyday context stay small without losing dates, corrections, or original wording?
+- After relevant history is found, how can an agent avoid presenting something that merely looks relevant as fact?
+
+StrataGate stores conversation history as memory blocks that can be expanded one layer at a time, then places an evidence gate before every answer.
+
+> [!NOTE]
+> This repository currently provides the core rules and an in-memory reference implementation. Node.js 20 or later is required.
+> The npm package has not been officially published, and there is no production database adapter or built-in model service yet.
+
+## Understand StrataGate in one minute
+
+```mermaid
+flowchart LR
+    A["Ongoing conversation"] --> B["Memory blocks"]
+    B --> C["L5 raw messages"]
+    C --> D["L2 key points"]
+    D --> E["L0 title and index"]
+    E -->|"need to verify"| C
+
+    Q["User question"] --> S["Search memory"]
+    S --> G{"Enough evidence?"}
+    G -->|"yes"| R["Answer"]
+    G -->|"no"| X["Keep searching or expand the source"]
+    X --> G
 ```
 
-StrataGate seals every 12 completed conversation turns into one permanent block. New blocks stay close to the original words. As the conversation moves on, older blocks appear in shorter forms. The full source is still there and can be opened again when a question needs a date, condition, correction, or exact quote.
+One user message and one assistant response count as a turn. By default, every 12 turns form a memory block. This value is configurable.
 
-The result is small everyday context without throwing old conversations away.
+Each block preserves several levels of detail at the same time. Old blocks normally use very little context. When a question depends on a date, exact wording, a condition, or a correction, only the relevant block is expanded. Shorter views never overwrite the complete source.
 
-## 🚦 2. Finding something is not the same as having an answer
+Retrieval is not “search once, then answer.” Every new batch of results must pass a constrained evidence check. When the evidence is incomplete, the next step can only be to continue searching, expand an event, inspect the raw messages, or state the uncertainty clearly.
 
-After every search, StrataGate asks one plain question: **is the newest evidence enough?**
+## Quick start
 
-```text
-Enough          → answer
-Only part of it → keep looking or open more detail
-Wrong result    → change the search route
-```
-
-Only the first path opens the answer gate. If the search budget ends while evidence is still incomplete, the agent must say that it is unsure instead of turning a related memory into a fact.
-
-These two rules are the heart of StrataGate: **memory has depth, and answers have a gate.**
-
-## 💡 Why this exists
-
-Most long-running assistants choose one of two bad compromises:
-
-- Send the whole conversation every time. Nothing is lost, but context keeps growing and useful details drown in noise.
-- Replace old conversation with summaries. Context stays small, but dates, wording, and corrections eventually vanish.
-
-StrataGate keeps the source and the smaller views together. The agent sees only the detail it needs now and can move back down to the original words later.
-
-## 🧱 What happens to one conversation
-
-A user message and its assistant reply count as one turn. After 12 completed turns, StrataGate creates one block with six views of the same conversation:
-
-| View | What the agent sees | Plain meaning |
-| --- | --- | --- |
-| L0 | Title and tags | An index entry |
-| L1 | Short summary | What this part was about |
-| L2 | Key points | The important facts |
-| L3 | Lightly cleaned transcript | Original conversation with only fixed kinds of clutter removed |
-| L4 | Readable near-original transcript | Almost every natural-language word |
-| L5 | Complete raw messages and tool records | The source |
-
-L3 does not ask a model to rewrite the conversation. Code removes only standalone greetings, pure confirmations, raw tool arguments, and exact repeated long pastes. L5 always remains complete.
-
-Older blocks normally show a shallower view. Opening a block lifts only that block to the requested depth; it does not flood the whole prompt with old history.
-
-> Twelve turns is the current tested default, not a claim that 12 is universally optimal. A 6/12/24-turn comparison has not been completed yet.
-
-## 🔎 What happens before an answer
-
-The agent searches in small steps. After each new result, it records five short fields:
-
-```text
-verdict · evidence_refs · fit · missing · next_strategy
-```
-
-In everyday language:
-
-- `verdict`: enough, partial, or wrong;
-- `evidence_refs`: which new results actually support the answer;
-- `fit`: why those results match the question;
-- `missing`: what is still absent;
-- `next_strategy`: answer, search again, or open more detail.
-
-A result can pass only when it is marked `sufficient`, cites evidence from the newest search batch, and chooses `answer` as the next step.
-
-## 🚀 Quick start
-
-StrataGate currently ships as a TypeScript core library. Node.js 20+ is required.
+Because the npm package has not been officially published, run StrataGate from source for now:
 
 ```bash
 git clone https://github.com/diqierjia/StrataGate.git
@@ -99,148 +60,221 @@ npm test
 npm run build
 ```
 
-```ts
-import { StrataGate } from '@diqier/stratagate';
+The example below runs a minimal workflow:
+
+1. Store two pieces of conversation.
+2. Extract a technical decision from the first one.
+3. Search for that decision.
+4. Assess the evidence.
+5. Record its use and output the answer only when the evidence is sufficient.
+
+Save the code as `demo.mjs` in the repository root:
+
+```js
+import { StrataGate } from './dist/index.js';
 
 const memory = new StrataGate({
-  // One turn only to keep this example short. The real default is 12.
+  // Use one turn here so the example creates a block immediately.
+  // The actual default is 12.
   blockTurnSize: 1,
 
   summarizer: async (messages) => ({
-    l0Title: 'API pagination decision',
+    l0Title: 'API pagination approach',
     l0Tags: ['api', 'decision'],
-    l1Summary: 'The team chose cursor pagination.',
+    l1Summary: 'The team decided to use cursor pagination for the public API.',
     l2Keypoints: messages.map((message) => message.content),
     shouldExtract: true,
   }),
 
   extractor: async ({ target }) => ({
     shouldExtract: true,
-    reason: 'This is a decision worth finding later.',
+    reason: 'The target block contains a technical decision that will matter later.',
     events: [{
-      title: 'Use cursor pagination',
-      summary: 'The public API should use cursor pagination.',
+      title: 'Use cursor pagination for the public API',
+      summary: 'The public API should use cursor pagination instead of page-number pagination.',
       sourceBlockId: target.id,
       sourceMessageIds: [target.l5Raw[0].id],
       tags: ['api', 'pagination'],
+      temporal: {
+        eventType: 'decision',
+        status: 'occurred',
+      },
     }],
   }),
 });
 
 await memory.appendTurn({
   user: 'Use cursor pagination for the public API.',
-  assistant: 'Agreed.',
+  assistant: 'Understood. I will treat it as the current API design decision.',
 });
 
-// Extraction waits for the following block, so it can tell a lasting
-// decision from a passing remark without taking quotes from a neighbor.
+// Event extraction processes the previous block only after a later block appears.
 await memory.appendTurn({
-  user: 'Now define the response envelope.',
+  user: 'Next, define the response structure.',
   assistant: 'Let us continue.',
 });
 
 const results = memory.searchEvents('How should the API paginate?');
-const newestEvidence = new Set(results.map(({ event }) => event.id));
+const latestEvidence = new Set(
+  results.map(({ event }) => event.id),
+);
 
-const check = memory.assessRetrieval({
+const assessment = memory.assessRetrieval({
   verdict: 'sufficient',
-  evidence_refs: [...newestEvidence],
-  fit: 'The selected memory records the decision.',
+  evidence_refs: [...latestEvidence],
+  fit: 'The retrieved event card directly records the pagination approach.',
   missing: '',
   next_strategy: 'answer',
-}, newestEvidence);
+}, latestEvidence);
 
-if (check.verdict === 'sufficient') {
-  memory.recordMemoryUse(check.evidenceRefs);
+if (assessment.verdict === 'sufficient') {
+  memory.recordMemoryUse(assessment.evidenceRefs);
+  console.log(results[0]?.event.summary);
+} else {
+  console.log('The current evidence is insufficient, so no definitive answer can be given yet.');
 }
 ```
 
-The core owns the memory rules. Applications provide the model calls through two small interfaces: one that creates the short block views and one that extracts lasting events. No model provider is built into the core.
+Run it:
 
-## 🔄 The whole flow
-
-```mermaid
-flowchart LR
-    A["Conversation"] --> B["12-turn block"]
-    B --> C["Exact words"]
-    C --> D["Key points"]
-    D --> E["Title + index"]
-    E -->|"need detail"| C
-
-    Q["Question"] --> S["Search"]
-    S --> G{"Enough evidence?"}
-    G -->|"enough"| R["Answer"]
-    G -->|"partial"| M["Look again or open more"]
-    G -->|"wrong"| N["Change search route"]
-    M --> G
-    N --> G
+```bash
+node demo.mjs
 ```
 
-## 🗂️ Helpful memory around those two rules
+The `summarizer` and `extractor` in this example are hard-coded callbacks. In a real integration, these interfaces can call any model or provider.
 
-StrataGate also keeps searchable event cards for decisions, preferences, plans, and corrections. Each card points to its source block and messages. Event time and message time are stored separately so a question about when something happened is not answered with the date it was mentioned.
+See [`examples/basic.ts`](examples/basic.ts) for the complete TypeScript example in this repository.
 
-These are supporting abilities. The main design remains the changing depth of old conversation and the evidence check before answering.
+## Conversation blocks: summaries never overwrite the source
 
-## ⚖️ Search should not make itself stronger
+Each memory block has six views:
 
-Simply finding a memory does not increase its long-term weight. A memory becomes stronger only after the answer actually uses it. This avoids a loop where frequently returned memories keep winning future searches merely because they were returned before.
+| Level | Contents | How it is produced |
+| --- | --- | --- |
+| L0 | Title and tags | `BlockSummarizer` |
+| L1 | Short summary | `BlockSummarizer` |
+| L2 | Key points | `BlockSummarizer` |
+| L3 | Rule-pruned conversation | Deterministic code |
+| L4 | Readable near-verbatim conversation | Deterministic code |
+| L5 | Complete messages and tool records | Preserved directly |
 
-Corrections also keep their history. A newer event can replace an older one without deleting the old source. A forgotten event leaves search but keeps its record unless an application explicitly deletes it.
+L3 does not allow a model to rewrite freely. It removes only narrowly defined content, such as standalone greetings, pure acknowledgements, raw tool arguments, and identical repeated long passages.
 
-## 📊 Evaluation: a development record, not a leaderboard
+L5 is always the final source of truth. Here, “preserved” means that shorter views never overwrite the original messages. Persistence across processes depends on the storage implementation supplied by the integrator. This repository currently provides only an in-memory reference implementation.
 
-The completed sequence below used one LoCoMo conversation (`conv-26`): 419 messages, 35 sessions, and 152 category 1-4 questions. Extraction used `gpt-4o-mini`; answering and judging used `gpt-4o`.
+The default block size is 12 turns, but that is only the default used by the current implementation and experiments. It is not a claim that 12 turns are optimal for every setting.
 
-This fixed slice helped us find improvements and regressions. It is not a full LoCoMo score and should not be compared directly with another project's full-dataset result.
+## Event cards: make important memories searchable
 
-| Run | What changed | Correct | Accuracy | What we learned |
-| --- | --- | ---: | ---: | --- |
-| 1 | 12-turn blocks, basic event cards, open older blocks when needed | 67 / 152 | 44.08% | The source stayed reachable, but too few useful events were found |
-| 2 | Allow several events from one block and store event time separately | 77 / 152 | 50.66% | Time questions improved, but answers sometimes needed facts from several cards |
-| 3 | Better extraction, more ways to open memory, and a check after every search | 116 / 152 | 76.32% | The complete search loop helped; one incorrect memory-use record was found |
-| 4 | Keep the evidence check short and fix the end-of-budget rule | 118 / 152 | 77.63% | Similar accuracy with about 10.35% fewer QA tokens and no recorded rule violations |
-| 5 | Replace the five short fields with a larger internal note | 97 / 152 | 63.82% | More internal text made retrieval worse, so we returned to run 4's smaller gate |
+Conversation blocks preserve the source. Event cards make important information easier to find.
 
-The failed fifth run matters: it is the reason the evidence gate stays small and strict.
+Event cards are suitable for representing:
 
-Different model and judge experiments are kept in [Evaluation](docs/EVALUATION.md), with their limits stated next to the numbers instead of mixing them into this improvement curve.
+- decisions;
+- preferences;
+- plans;
+- corrections;
+- time-related events.
 
-## ✅ What is ready today
+Every event card records its source block and source messages. The time when an event happened is stored separately from the time when it was mentioned, so the system does not mistake “when the conversation happened” for “when the event happened.”
 
-- permanent conversation blocks and six levels of detail;
-- deterministic L3-L5 views;
-- block expansion that opens only the needed history;
-- an adapter for delayed event extraction;
-- searchable event cards and raw-message fallback;
-- the three-way evidence check;
-- memory use, pin, forget, restore, and correction rules;
-- tests for the core behavior.
+Event extraction is delayed by one block by default. When extracting block `N`, adjacent blocks may provide context, but the facts and citations of a new event can come only from block `N` itself.
 
-## 🚧 What is not claimed yet
+## Evidence gate: relevant does not mean sufficient
+
+Each batch of search results produces five fields:
+
+| Field | Meaning |
+| --- | --- |
+| `verdict` | The evidence is sufficient, only partial, or wrong |
+| `evidence_refs` | Which items in the latest result batch actually support the answer |
+| `fit` | Why this evidence answers the current question |
+| `missing` | What is still missing |
+| `next_strategy` | Answer, search again, or expand more source material |
+
+A `sufficient` verdict is accepted only when all three conditions below are met:
+
+1. At least one cited piece of evidence comes from the latest retrieval batch.
+2. The next step explicitly selects `answer`.
+3. The assessment conforms to the constrained field structure.
+
+Otherwise, the core downgrades the result to `partial` or `wrong`.
+
+StrataGate provides the evidence gate and state rules. The integration is still responsible for the tool-calling loop and the model that produces the final answer.
+
+## Search hits do not reinforce memory automatically
+
+A search hit only means that a memory was found. It does not mean the answer actually used it.
+
+An event's long-term weight is updated only after `recordMemoryUse()` records that it was actually used. This prevents a memory from reinforcing itself and dominating future rankings simply because it appears frequently in search results.
+
+Corrections do not overwrite history directly. A new event can supersede an old one, while the old event and its source remain available. Forgetting removes an event from search; it does not delete the original conversation by default.
+
+## Evaluation record
+
+The current public experiments document development iterations and help identify regressions. They are not presented as leaderboard scores.
+
+Five development runs used the same LoCoMo conversation (`conv-26`), containing 419 messages, 35 sessions, and 152 category 1–4 questions.
+
+The two results that most directly shaped the current design are:
+
+| Configuration | Correct | Accuracy |
+| --- | ---: | ---: |
+| Five-field evidence gate with constrained assessment context | 118 / 152 | 77.63% |
+| Replaced it with a more complex retrieval note | 97 / 152 | 63.82% |
+
+The more complex internal retrieval state caused a clear regression, so the current implementation keeps the shorter, enforceable five-field contract.
+
+This is a fixed development slice, not a complete LoCoMo evaluation, and it cannot be compared directly with full-dataset results from other projects. See [`docs/EVALUATION.md`](docs/EVALUATION.md) for the complete experiment history, model configuration, and Judge sensitivity.
+
+## Current scope
+
+Available today:
+
+- L0–L5 layered conversation blocks;
+- deterministic L3–L5 source views;
+- on-demand expansion of individual historical blocks;
+- a delayed event extraction interface;
+- event cards with source and time information;
+- event search and raw-message lookup;
+- a three-way evidence gate;
+- weight updates after actual use;
+- pinning, forgetting, restoring, and event supersession;
+- tests for core behavior.
+
+Not yet provided:
 
 - a production database adapter;
-- a published npm package;
-- a built-in model provider;
-- embedding, reranking, or graph search in the open-source core;
-- proof that 12 turns is better than every other block size;
-- a full LoCoMo result under one frozen end-to-end setup.
+- an officially published npm package;
+- a built-in model service;
+- embeddings, reranking, or graph retrieval;
+- a unified end-to-end result on the complete LoCoMo dataset;
+- evidence that a 12-turn block size is better than other configurations.
 
-## 📁 Repository layout
+StrataGate is therefore currently best suited for:
+
+- researching or building traceable agent memory systems;
+- validating layered context and evidence-gate designs;
+- serving as the memory kernel inside an existing agent framework.
+
+It is not yet a hosted memory service that can be installed and used directly in production.
+
+## Repository layout
 
 ```text
 src/
-  blocks.ts       how one conversation moves between exact words and an index
-  retrieval.ts    the three-way evidence gate
-  store.ts        the working in-memory reference implementation
-  types.ts        the public data shapes and model adapter interfaces
-  weights.ts      how actually used memories stay stronger for longer
-tests/            the rules expressed as executable tests
-examples/         a small integration example
-docs/             deeper architecture and evaluation details
-benchmarks/       machine-readable development-run summaries
+  blocks.ts       conversation block layering and decay
+  retrieval.ts    evidence assessment contract
+  store.ts        in-memory reference implementation
+  types.ts        data structures and adapter interfaces
+  weights.ts      memory weight rules
+
+tests/            tests for core rules
+examples/         minimal integration example
+docs/             architecture and evaluation documentation
+benchmarks/       machine-readable experiment records
 ```
 
-## 📄 License
+## License
 
 StrataGate is available under the [MIT License](LICENSE).


### PR DESCRIPTION
## What changed

- rewrote `README.md` as a complete English translation of the current Chinese README
- synchronized the overview, source-based quickstart, full example, memory-block rules, evidence gate, evaluation highlights, and current scope
- removed outdated English-only sections and claims so both versions now describe the same project

## Why

The English README had fallen out of sync after the Chinese README was replaced. Readers in both languages should see the same structure, examples, evidence, and limitations.

## Validation

- Chinese and English heading positions match
- both versions contain 10 Markdown fences and 19 table rows
- all local README links resolve
- `git diff --check`
- `npm test` (5 tests passed)
- `npm run build`
