### PR TITLE
Add transactional SQLite persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,42 @@ Search updates only the retrieval record. The system calls `recordMemoryUse()` t
 
 A new event may supersede an old one, but the old source remains traceable. Forgetting removes an event from search while preserving the source chain.
 
+## Persistent SQLite storage
+
+The default constructor remains an in-memory reference implementation. For restart-safe memory, install the optional SQLite driver:
+
+```bash
+npm install @diqier/stratagate better-sqlite3
+```
+
+```ts
+import { StrataGate } from '@diqier/stratagate';
+import { SqliteStorage } from '@diqier/stratagate/sqlite';
+
+const memory = await StrataGate.open({
+  storage: new SqliteStorage({ filename: './data/stratagate.db' }),
+  namespace: 'user:alice',
+  summarizer,
+  extractor,
+});
+
+await memory.appendTurn({ user, assistant });
+const results = await memory.searchEvents(question);
+
+await memory.recordMemoryUse(
+  results.map(({ event }) => event.id),
+  { receiptId: `answer:${answerMessageId}` },
+);
+
+await memory.close();
+```
+
+SQLite stores open-tail messages, sealed L0-L5 blocks, event provenance, extraction jobs, pointer anchors, and adoption receipts. Writes use transactions and per-namespace revisions. A stale writer is rejected instead of silently overwriting newer memory.
+
+Raw turns are committed before summarization or extraction calls. If either model call fails, `resumePendingWork()` continues only the unfinished block after restart. Persistent adoption requires a stable `receiptId`, so retrying one answer does not strengthen the same event twice.
+
+The adapter enables WAL and foreign-key enforcement. The database file is not encrypted by StrataGate; applications that store sensitive conversations must secure it at the filesystem or database layer.
+
 ## Evaluation
 
 The evaluation document includes:
@@ -153,7 +189,7 @@ See [`docs/EVALUATION.md`](docs/EVALUATION.md).
 - rebuild the StrataGate memory state with GPT-5.6 Sol;
 - run ablations on temporal fields, event cards, and raw-message fallback;
 - complete a reproducible clean Mem0 run;
-- expand storage adapters and retrieval implementations.
+- add a real framework adapter and database-native retrieval indexes.
 
 ## Repository layout
 
@@ -161,7 +197,9 @@ See [`docs/EVALUATION.md`](docs/EVALUATION.md).
 src/
   blocks.ts       Conversation-block layering and decay
   retrieval.ts    Evidence-gate contract
-  store.ts        In-memory reference implementation
+  storage.ts      Persistence snapshot and adapter contracts
+  sqlite.ts       Transactional SQLite adapter
+  store.ts        In-memory and persistent lifecycle
   types.ts        Data structures and model-adapter interfaces
   weights.ts      Memory adoption and weighting rules
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,6 +135,42 @@ verdict · evidence_refs · fit · missing · next_strategy
 
 新事件可以取代旧事件，但旧来源仍然可追溯；遗忘会让事件退出搜索，同时保留来源链路。
 
+## SQLite 持久化存储
+
+默认构造函数仍然提供内存参考实现。如需让记忆在进程重启后恢复，安装可选的 SQLite 驱动：
+
+```bash
+npm install @diqier/stratagate better-sqlite3
+```
+
+```ts
+import { StrataGate } from '@diqier/stratagate';
+import { SqliteStorage } from '@diqier/stratagate/sqlite';
+
+const memory = await StrataGate.open({
+  storage: new SqliteStorage({ filename: './data/stratagate.db' }),
+  namespace: 'user:alice',
+  summarizer,
+  extractor,
+});
+
+await memory.appendTurn({ user, assistant });
+const results = await memory.searchEvents(question);
+
+await memory.recordMemoryUse(
+  results.map(({ event }) => event.id),
+  { receiptId: `answer:${answerMessageId}` },
+);
+
+await memory.close();
+```
+
+SQLite 会保存未封块的原始消息、已封存的 L0-L5、事件来源、抽取任务、指针锚点和采用回执。所有写入使用事务和 namespace revision；旧进程继续写入时会得到冲突错误，不会静默覆盖新记忆。
+
+原始 turn 会在摘要和抽取模型调用前提交。任一模型调用失败后，重启进程并调用 `resumePendingWork()`，只会继续未完成的 block。持久化模式下采用记忆必须传入稳定的 `receiptId`，同一个回答即使重试也不会重复强化事件。
+
+适配器会启用 WAL 和外键检查。StrataGate 本身不加密数据库文件；保存敏感对话时，应用必须在文件系统或数据库层提供保护。
+
 ## 评测
 
 评测文档包含：
@@ -153,7 +189,7 @@ verdict · evidence_refs · fit · missing · next_strategy
 - 使用 GPT-5.6 Sol 重新构建 StrataGate memory state；
 - 对时间字段、事件卡和原文回查做消融实验；
 - 完成可复现的 Mem0 clean run；
-- 扩展存储适配器与检索实现。
+- 增加一个真实框架 adapter 和数据库原生检索索引。
 
 ## 项目结构
 
@@ -161,7 +197,9 @@ verdict · evidence_refs · fit · missing · next_strategy
 src/
   blocks.ts       对话块分层与衰减
   retrieval.ts    证据门合同
-  store.ts        内存参考实现
+  storage.ts      持久化快照与 adapter 合同
+  sqlite.ts       事务式 SQLite adapter
+  store.ts        内存与持久化生命周期
   types.ts        数据结构与模型适配接口
   weights.ts      记忆采用与权重规则
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -169,13 +169,24 @@ If the retrieval budget ends without sufficient evidence, the caller should pass
 
 ## Storage adapters
 
-The current repository contains an in-memory reference store. A production adapter should preserve these invariants:
+The default constructor is an in-memory reference store. `StrataGate.open()` can instead hydrate the same state machine from a `StorageAdapter`. The bundled `SqliteStorage` adapter persists normalized rows for memory spaces, messages, blocks, events, event sources, extraction jobs, and usage receipts.
+
+Every namespace has a monotonically increasing revision. A write supplies the revision it loaded; SQLite commits the new revision and all related rows in one immediate transaction. A stale process receives `StorageConflictError` rather than overwriting newer state.
+
+External model calls are never made inside a database transaction:
+
+1. a completed raw turn is committed immediately;
+2. summarization runs outside the transaction, then sealing commits atomically;
+3. extraction first commits a running job, calls the extractor, then atomically commits either the event cards or a failed/skipped job state;
+4. `resumePendingWork()` retries only failed or interrupted work after restart.
+
+The adapter preserves these invariants:
 
 - blocks and L5 messages are append-only;
 - card provenance references an existing source block and message set;
 - search hits do not increment adoption state;
 - supersession retains the old event;
 - forget is reversible unless an application explicitly implements irreversible deletion;
-- usage receipts are idempotent for one answer turn.
+- usage receipts are idempotent for one answer turn through a unique `receiptId`.
 
-SQLite and Postgres adapters are planned, but are not claimed as complete in the initial open-source release.
+SQLite uses WAL, foreign keys, and per-namespace optimistic concurrency. It does not provide encryption at rest. Search still uses the reference in-memory ranking after hydration, so enabling persistence does not silently change retrieval semantics. Database-native lexical/vector indexes and a Postgres implementation remain separate future work.

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -35,7 +35,7 @@ await memory.appendTurn({
   assistant: 'I will keep the pagination decision in mind.',
 });
 
-const results = memory.searchEvents('How should the API paginate?');
+const results = await memory.searchEvents('How should the API paginate?');
 const evidence = new Set(results.map(({ event }) => event.id));
 const assessment = memory.assessRetrieval({
   verdict: 'sufficient',
@@ -46,6 +46,6 @@ const assessment = memory.assessRetrieval({
 }, evidence);
 
 if (assessment.verdict === 'sufficient') {
-  memory.recordMemoryUse(assessment.evidenceRefs);
+  await memory.recordMemoryUse(assessment.evidenceRefs);
   console.log(results[0]?.event.summary);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,22 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.0.0",
+        "better-sqlite3": "^12.11.1",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "better-sqlite3": "^12.11.1"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -833,6 +843,16 @@
         "win32"
       ]
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -993,6 +1013,89 @@
         "node": ">=12"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1030,6 +1133,13 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1048,6 +1158,22 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1056,6 +1182,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1117,6 +1273,16 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -1145,6 +1311,20 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1159,6 +1339,48 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -1184,6 +1406,36 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1208,6 +1460,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/pathe": {
@@ -1276,6 +1558,76 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
@@ -1322,12 +1674,93 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1353,6 +1786,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -1364,6 +1817,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -1427,6 +1910,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1445,6 +1941,13 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1635,6 +2138,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./sqlite": {
+      "types": "./dist/sqlite.d.ts",
+      "import": "./dist/sqlite.js"
     }
   },
   "files": [
@@ -43,11 +47,21 @@
   "homepage": "https://github.com/diqierjia/StrataGate#readme",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
+    "better-sqlite3": "^12.11.1",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
+  },
+  "peerDependencies": {
+    "better-sqlite3": "^12.11.1"
+  },
+  "peerDependenciesMeta": {
+    "better-sqlite3": {
+      "optional": true
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './blocks.js';
 export * from './retrieval.js';
+export * from './storage.js';
 export * from './store.js';
 export * from './types.js';
 export * from './weights.js';

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -1,0 +1,638 @@
+import Database from 'better-sqlite3';
+import {
+  STRATAGATE_STORAGE_SCHEMA_VERSION,
+  StorageConflictError,
+  assertValidSnapshot,
+  cloneSnapshot,
+  type ExtractionJob,
+  type LoadedStrataGateState,
+  type StorageAdapter,
+  type StrataGateSnapshot,
+  type UsageReceipt,
+} from './storage.js';
+import type {
+  BlockLevel,
+  EventCard,
+  EventTemporal,
+  MemoryBlock,
+  MemoryCriticality,
+  MemoryScope,
+  MemoryStatus,
+  RawMessage,
+  ToolTrace,
+} from './types.js';
+
+export interface SqliteStorageOptions {
+  filename: string;
+  readonly?: boolean;
+  timeoutMs?: number;
+}
+
+interface SpaceRow {
+  schema_version: number;
+  revision: number;
+  current_turn: number;
+  block_turn_size: number;
+}
+
+interface MessageRow {
+  id: string;
+  block_id: string | null;
+  position: number;
+  role: RawMessage['role'];
+  content: string;
+  created_at: string;
+  tool_calls_json: string | null;
+}
+
+interface BlockRow {
+  id: string;
+  sequence: number;
+  start_turn: number;
+  end_turn: number;
+  created_at: string;
+  should_extract: number;
+  l0_title: string;
+  l0_tags_json: string;
+  l1_summary: string;
+  l2_keypoints_json: string;
+  l3_condensed: string;
+  l4_readable: string;
+  pointer_current_level: number;
+  pointer_anchor_level: number;
+  pointer_anchor_turn: number;
+  last_lifted_at: string | null;
+}
+
+interface EventRow {
+  id: string;
+  position: number;
+  title: string;
+  summary: string;
+  narrative: string;
+  tags_json: string;
+  quotes_json: string;
+  source_block_id: string;
+  temporal_json: string;
+  scope: MemoryScope;
+  criticality: MemoryCriticality;
+  confidence: number;
+  status: MemoryStatus;
+  superseded_by: string | null;
+  mention_count: number;
+  last_adopted_turn: number;
+  last_retrieved_at: string | null;
+  pinned: number;
+  floor_weight: number;
+  forced_cap: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface EventSourceRow {
+  event_id: string;
+  message_id: string;
+  position: number;
+}
+
+interface ExtractionJobRow {
+  block_id: string;
+  status: ExtractionJob['status'];
+  attempts: number;
+  last_error: string | null;
+  updated_at: string;
+}
+
+interface UsageReceiptRow {
+  receipt_id: string;
+  event_ids_json: string;
+  created_at: string;
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS memory_spaces (
+  namespace TEXT PRIMARY KEY,
+  schema_version INTEGER NOT NULL,
+  revision INTEGER NOT NULL,
+  current_turn INTEGER NOT NULL,
+  block_turn_size INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS blocks (
+  namespace TEXT NOT NULL,
+  id TEXT NOT NULL,
+  sequence INTEGER NOT NULL,
+  start_turn INTEGER NOT NULL,
+  end_turn INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  should_extract INTEGER NOT NULL,
+  l0_title TEXT NOT NULL,
+  l0_tags_json TEXT NOT NULL,
+  l1_summary TEXT NOT NULL,
+  l2_keypoints_json TEXT NOT NULL,
+  l3_condensed TEXT NOT NULL,
+  l4_readable TEXT NOT NULL,
+  pointer_current_level INTEGER NOT NULL,
+  pointer_anchor_level INTEGER NOT NULL,
+  pointer_anchor_turn INTEGER NOT NULL,
+  last_lifted_at TEXT,
+  PRIMARY KEY (namespace, id),
+  UNIQUE (namespace, sequence),
+  FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS messages (
+  namespace TEXT NOT NULL,
+  id TEXT NOT NULL,
+  block_id TEXT,
+  position INTEGER NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  tool_calls_json TEXT,
+  PRIMARY KEY (namespace, id),
+  FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE,
+  FOREIGN KEY (namespace, block_id) REFERENCES blocks(namespace, id) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS messages_container_idx ON messages(namespace, block_id, position);
+
+CREATE TABLE IF NOT EXISTS events (
+  namespace TEXT NOT NULL,
+  id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  narrative TEXT NOT NULL,
+  tags_json TEXT NOT NULL,
+  quotes_json TEXT NOT NULL,
+  source_block_id TEXT NOT NULL,
+  temporal_json TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  criticality TEXT NOT NULL,
+  confidence REAL NOT NULL,
+  status TEXT NOT NULL,
+  superseded_by TEXT,
+  mention_count INTEGER NOT NULL,
+  last_adopted_turn INTEGER NOT NULL,
+  last_retrieved_at TEXT,
+  pinned INTEGER NOT NULL,
+  floor_weight REAL NOT NULL,
+  forced_cap REAL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (namespace, id),
+  FOREIGN KEY (namespace, source_block_id) REFERENCES blocks(namespace, id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS event_sources (
+  namespace TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  PRIMARY KEY (namespace, event_id, message_id),
+  FOREIGN KEY (namespace, event_id) REFERENCES events(namespace, id) ON DELETE CASCADE,
+  FOREIGN KEY (namespace, message_id) REFERENCES messages(namespace, id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS extraction_jobs (
+  namespace TEXT NOT NULL,
+  block_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  attempts INTEGER NOT NULL,
+  last_error TEXT,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (namespace, block_id),
+  FOREIGN KEY (namespace, block_id) REFERENCES blocks(namespace, id) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS usage_receipts (
+  namespace TEXT NOT NULL,
+  receipt_id TEXT NOT NULL,
+  event_ids_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (namespace, receipt_id),
+  FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE
+) STRICT;
+`;
+
+function parseJson<T>(value: string, label: string): T {
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    throw new Error(`Invalid JSON in SQLite column ${label}`, { cause: error });
+  }
+}
+
+function nonEmptyNamespace(namespace: string): string {
+  const normalized = namespace.trim();
+  if (!normalized) throw new TypeError('Storage namespace must not be empty');
+  return normalized;
+}
+
+export class SqliteStorage implements StorageAdapter {
+  private readonly database: Database.Database;
+  private closed = false;
+
+  constructor(options: SqliteStorageOptions) {
+    if (!options.filename.trim()) throw new TypeError('SQLite filename must not be empty');
+    this.database = new Database(options.filename, {
+      readonly: options.readonly ?? false,
+      timeout: Math.max(0, Math.floor(options.timeoutMs ?? 5_000)),
+    });
+    try {
+      this.database.pragma('foreign_keys = ON');
+      if (!(options.readonly ?? false)) {
+        this.database.pragma('journal_mode = WAL');
+        this.migrate();
+      } else {
+        this.assertSchemaVersion();
+      }
+    } catch (error) {
+      this.database.close();
+      this.closed = true;
+      throw error;
+    }
+  }
+
+  async load(namespace: string): Promise<LoadedStrataGateState | null> {
+    this.assertOpen();
+    const key = nonEmptyNamespace(namespace);
+    const space = this.database.prepare(`
+      SELECT schema_version, revision, current_turn, block_turn_size
+      FROM memory_spaces WHERE namespace = ?
+    `).get(key) as SpaceRow | undefined;
+    if (!space) return null;
+    if (space.schema_version !== STRATAGATE_STORAGE_SCHEMA_VERSION) {
+      throw new Error(`Unsupported stored StrataGate schema: ${space.schema_version}`);
+    }
+
+    const messageRows = this.database.prepare(`
+      SELECT id, block_id, position, role, content, created_at, tool_calls_json
+      FROM messages WHERE namespace = ? ORDER BY block_id, position
+    `).all(key) as MessageRow[];
+    const openTail: RawMessage[] = [];
+    const messagesByBlock = new Map<string, RawMessage[]>();
+    for (const row of messageRows) {
+      const message: RawMessage = {
+        id: row.id,
+        role: row.role,
+        content: row.content,
+        createdAt: row.created_at,
+        ...(row.tool_calls_json ? { toolCalls: parseJson<ToolTrace[]>(row.tool_calls_json, 'messages.tool_calls_json') } : {}),
+      };
+      if (row.block_id === null) openTail.push(message);
+      else {
+        const messages = messagesByBlock.get(row.block_id) ?? [];
+        messages.push(message);
+        messagesByBlock.set(row.block_id, messages);
+      }
+    }
+
+    const blockRows = this.database.prepare(`
+      SELECT * FROM blocks WHERE namespace = ? ORDER BY sequence
+    `).all(key) as BlockRow[];
+    const blocks: MemoryBlock[] = blockRows.map((row) => ({
+      id: row.id,
+      sequence: row.sequence,
+      startTurn: row.start_turn,
+      endTurn: row.end_turn,
+      createdAt: row.created_at,
+      shouldExtract: Boolean(row.should_extract),
+      l0Title: row.l0_title,
+      l0Tags: parseJson<string[]>(row.l0_tags_json, 'blocks.l0_tags_json'),
+      l1Summary: row.l1_summary,
+      l2Keypoints: parseJson<string[]>(row.l2_keypoints_json, 'blocks.l2_keypoints_json'),
+      l3Condensed: row.l3_condensed,
+      l4Readable: row.l4_readable,
+      l5Raw: messagesByBlock.get(row.id) ?? [],
+      pointerCurrentLevel: row.pointer_current_level as BlockLevel,
+      pointerAnchorLevel: row.pointer_anchor_level as BlockLevel,
+      pointerAnchorTurn: row.pointer_anchor_turn,
+      lastLiftedAt: row.last_lifted_at,
+    }));
+
+    const sourceRows = this.database.prepare(`
+      SELECT event_id, message_id, position FROM event_sources
+      WHERE namespace = ? ORDER BY event_id, position
+    `).all(key) as EventSourceRow[];
+    const sourcesByEvent = new Map<string, string[]>();
+    for (const row of sourceRows) {
+      const ids = sourcesByEvent.get(row.event_id) ?? [];
+      ids.push(row.message_id);
+      sourcesByEvent.set(row.event_id, ids);
+    }
+
+    const eventRows = this.database.prepare(`
+      SELECT * FROM events WHERE namespace = ? ORDER BY position
+    `).all(key) as EventRow[];
+    const events: EventCard[] = eventRows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      summary: row.summary,
+      narrative: row.narrative,
+      tags: parseJson<string[]>(row.tags_json, 'events.tags_json'),
+      quotes: parseJson<string[]>(row.quotes_json, 'events.quotes_json'),
+      sourceMessageIds: sourcesByEvent.get(row.id) ?? [],
+      sourceBlockId: row.source_block_id,
+      temporal: parseJson<EventTemporal>(row.temporal_json, 'events.temporal_json'),
+      scope: row.scope,
+      criticality: row.criticality,
+      confidence: row.confidence,
+      status: row.status,
+      supersededBy: row.superseded_by,
+      weight: {
+        mentionCount: row.mention_count,
+        lastAdoptedTurn: row.last_adopted_turn,
+        lastRetrievedAt: row.last_retrieved_at,
+        pinned: Boolean(row.pinned),
+        floorWeight: row.floor_weight,
+        forcedCap: row.forced_cap,
+      },
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+
+    const extractionJobs = (this.database.prepare(`
+      SELECT block_id, status, attempts, last_error, updated_at
+      FROM extraction_jobs WHERE namespace = ? ORDER BY block_id
+    `).all(key) as ExtractionJobRow[]).map<ExtractionJob>((row) => ({
+      blockId: row.block_id,
+      status: row.status,
+      attempts: row.attempts,
+      lastError: row.last_error,
+      updatedAt: row.updated_at,
+    }));
+
+    const usageReceipts = (this.database.prepare(`
+      SELECT receipt_id, event_ids_json, created_at
+      FROM usage_receipts WHERE namespace = ? ORDER BY created_at, receipt_id
+    `).all(key) as UsageReceiptRow[]).map<UsageReceipt>((row) => ({
+      id: row.receipt_id,
+      eventIds: parseJson<string[]>(row.event_ids_json, 'usage_receipts.event_ids_json'),
+      createdAt: row.created_at,
+    }));
+
+    const snapshot: StrataGateSnapshot = {
+      schemaVersion: STRATAGATE_STORAGE_SCHEMA_VERSION,
+      currentTurn: space.current_turn,
+      blockTurnSize: space.block_turn_size,
+      openTail,
+      blocks,
+      events,
+      extractionJobs,
+      usageReceipts,
+    };
+    assertValidSnapshot(snapshot);
+    return { snapshot: cloneSnapshot(snapshot), revision: space.revision };
+  }
+
+  async save(namespace: string, snapshot: StrataGateSnapshot, expectedRevision: number): Promise<number> {
+    this.assertOpen();
+    assertValidSnapshot(snapshot);
+    if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 0) {
+      throw new TypeError('expectedRevision must be a non-negative integer');
+    }
+    const key = nonEmptyNamespace(namespace);
+    const persist = this.database.transaction(() => this.persistSnapshot(key, snapshot, expectedRevision));
+    return persist.immediate();
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.database.close();
+    this.closed = true;
+  }
+
+  private persistSnapshot(namespace: string, snapshot: StrataGateSnapshot, expectedRevision: number): number {
+    const current = this.database.prepare('SELECT revision FROM memory_spaces WHERE namespace = ?')
+      .get(namespace) as { revision: number } | undefined;
+    const actualRevision = current?.revision ?? null;
+    if ((actualRevision ?? 0) !== expectedRevision || (actualRevision === null && expectedRevision !== 0)) {
+      throw new StorageConflictError(namespace, expectedRevision, actualRevision);
+    }
+
+    const nextRevision = expectedRevision + 1;
+    const updatedAt = new Date().toISOString();
+    if (current) {
+      this.database.prepare(`
+        UPDATE memory_spaces
+        SET schema_version = ?, revision = ?, current_turn = ?, block_turn_size = ?, updated_at = ?
+        WHERE namespace = ?
+      `).run(
+        snapshot.schemaVersion,
+        nextRevision,
+        snapshot.currentTurn,
+        snapshot.blockTurnSize,
+        updatedAt,
+        namespace,
+      );
+    } else {
+      this.database.prepare(`
+        INSERT INTO memory_spaces (
+          namespace, schema_version, revision, current_turn, block_turn_size, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        namespace,
+        snapshot.schemaVersion,
+        nextRevision,
+        snapshot.currentTurn,
+        snapshot.blockTurnSize,
+        updatedAt,
+        updatedAt,
+      );
+    }
+
+    const insertBlock = this.database.prepare(`
+      INSERT INTO blocks (
+        namespace, id, sequence, start_turn, end_turn, created_at, should_extract,
+        l0_title, l0_tags_json, l1_summary, l2_keypoints_json, l3_condensed, l4_readable,
+        pointer_current_level, pointer_anchor_level, pointer_anchor_turn, last_lifted_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (namespace, id) DO UPDATE SET
+        sequence = excluded.sequence,
+        start_turn = excluded.start_turn,
+        end_turn = excluded.end_turn,
+        created_at = excluded.created_at,
+        should_extract = excluded.should_extract,
+        l0_title = excluded.l0_title,
+        l0_tags_json = excluded.l0_tags_json,
+        l1_summary = excluded.l1_summary,
+        l2_keypoints_json = excluded.l2_keypoints_json,
+        l3_condensed = excluded.l3_condensed,
+        l4_readable = excluded.l4_readable,
+        pointer_current_level = excluded.pointer_current_level,
+        pointer_anchor_level = excluded.pointer_anchor_level,
+        pointer_anchor_turn = excluded.pointer_anchor_turn,
+        last_lifted_at = excluded.last_lifted_at
+    `);
+    for (const block of snapshot.blocks) {
+      insertBlock.run(
+        namespace,
+        block.id,
+        block.sequence,
+        block.startTurn,
+        block.endTurn,
+        block.createdAt,
+        Number(block.shouldExtract),
+        block.l0Title,
+        JSON.stringify(block.l0Tags),
+        block.l1Summary,
+        JSON.stringify(block.l2Keypoints),
+        block.l3Condensed,
+        block.l4Readable,
+        block.pointerCurrentLevel,
+        block.pointerAnchorLevel,
+        block.pointerAnchorTurn,
+        block.lastLiftedAt,
+      );
+    }
+
+    const insertMessage = this.database.prepare(`
+      INSERT INTO messages (
+        namespace, id, block_id, position, role, content, created_at, tool_calls_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (namespace, id) DO UPDATE SET
+        block_id = excluded.block_id,
+        position = excluded.position,
+        role = excluded.role,
+        content = excluded.content,
+        created_at = excluded.created_at,
+        tool_calls_json = excluded.tool_calls_json
+    `);
+    const insertMessages = (messages: readonly RawMessage[], blockId: string | null): void => {
+      for (const [position, message] of messages.entries()) {
+        insertMessage.run(
+          namespace,
+          message.id,
+          blockId,
+          position,
+          message.role,
+          message.content,
+          message.createdAt,
+          message.toolCalls ? JSON.stringify(message.toolCalls) : null,
+        );
+      }
+    };
+    insertMessages(snapshot.openTail, null);
+    for (const block of snapshot.blocks) insertMessages(block.l5Raw, block.id);
+
+    const insertEvent = this.database.prepare(`
+      INSERT INTO events (
+        namespace, id, position, title, summary, narrative, tags_json, quotes_json, source_block_id,
+        temporal_json, scope, criticality, confidence, status, superseded_by,
+        mention_count, last_adopted_turn, last_retrieved_at, pinned, floor_weight, forced_cap,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (namespace, id) DO UPDATE SET
+        position = excluded.position,
+        title = excluded.title,
+        summary = excluded.summary,
+        narrative = excluded.narrative,
+        tags_json = excluded.tags_json,
+        quotes_json = excluded.quotes_json,
+        source_block_id = excluded.source_block_id,
+        temporal_json = excluded.temporal_json,
+        scope = excluded.scope,
+        criticality = excluded.criticality,
+        confidence = excluded.confidence,
+        status = excluded.status,
+        superseded_by = excluded.superseded_by,
+        mention_count = excluded.mention_count,
+        last_adopted_turn = excluded.last_adopted_turn,
+        last_retrieved_at = excluded.last_retrieved_at,
+        pinned = excluded.pinned,
+        floor_weight = excluded.floor_weight,
+        forced_cap = excluded.forced_cap,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at
+    `);
+    const insertEventSource = this.database.prepare(`
+      INSERT INTO event_sources (namespace, event_id, message_id, position) VALUES (?, ?, ?, ?)
+      ON CONFLICT (namespace, event_id, message_id) DO UPDATE SET position = excluded.position
+    `);
+    for (const [eventPosition, event] of snapshot.events.entries()) {
+      insertEvent.run(
+        namespace,
+        event.id,
+        eventPosition,
+        event.title,
+        event.summary,
+        event.narrative,
+        JSON.stringify(event.tags),
+        JSON.stringify(event.quotes),
+        event.sourceBlockId,
+        JSON.stringify(event.temporal),
+        event.scope,
+        event.criticality,
+        event.confidence,
+        event.status,
+        event.supersededBy,
+        event.weight.mentionCount,
+        event.weight.lastAdoptedTurn,
+        event.weight.lastRetrievedAt,
+        Number(event.weight.pinned),
+        event.weight.floorWeight,
+        event.weight.forcedCap,
+        event.createdAt,
+        event.updatedAt,
+      );
+      for (const [position, messageId] of event.sourceMessageIds.entries()) {
+        insertEventSource.run(namespace, event.id, messageId, position);
+      }
+    }
+
+    const insertJob = this.database.prepare(`
+      INSERT INTO extraction_jobs (
+        namespace, block_id, status, attempts, last_error, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT (namespace, block_id) DO UPDATE SET
+        status = excluded.status,
+        attempts = excluded.attempts,
+        last_error = excluded.last_error,
+        updated_at = excluded.updated_at
+    `);
+    for (const job of snapshot.extractionJobs) {
+      insertJob.run(namespace, job.blockId, job.status, job.attempts, job.lastError, job.updatedAt);
+    }
+
+    const insertReceipt = this.database.prepare(`
+      INSERT INTO usage_receipts (namespace, receipt_id, event_ids_json, created_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT (namespace, receipt_id) DO NOTHING
+    `);
+    for (const receipt of snapshot.usageReceipts) {
+      insertReceipt.run(namespace, receipt.id, JSON.stringify(receipt.eventIds), receipt.createdAt);
+    }
+
+    return nextRevision;
+  }
+
+  private migrate(): void {
+    const version = this.database.pragma('user_version', { simple: true }) as number;
+    if (version > STRATAGATE_STORAGE_SCHEMA_VERSION) {
+      throw new Error(`SQLite schema ${version} is newer than supported schema ${STRATAGATE_STORAGE_SCHEMA_VERSION}`);
+    }
+    if (version === 0) {
+      const migrate = this.database.transaction(() => {
+        this.database.exec(SCHEMA);
+        this.database.pragma(`user_version = ${STRATAGATE_STORAGE_SCHEMA_VERSION}`);
+      });
+      migrate.immediate();
+    }
+    this.assertSchemaVersion();
+  }
+
+  private assertSchemaVersion(): void {
+    const version = this.database.pragma('user_version', { simple: true }) as number;
+    if (version !== STRATAGATE_STORAGE_SCHEMA_VERSION) {
+      throw new Error(`Unsupported SQLite schema version: ${version}`);
+    }
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new Error('SQLite storage is closed');
+  }
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,73 @@
+import type { EventCard, MemoryBlock, RawMessage } from './types.js';
+
+export const STRATAGATE_STORAGE_SCHEMA_VERSION = 1;
+
+export type ExtractionJobStatus = 'running' | 'succeeded' | 'skipped' | 'failed';
+
+export interface ExtractionJob {
+  blockId: string;
+  status: ExtractionJobStatus;
+  attempts: number;
+  lastError: string | null;
+  updatedAt: string;
+}
+
+export interface UsageReceipt {
+  id: string;
+  eventIds: string[];
+  createdAt: string;
+}
+
+export interface StrataGateSnapshot {
+  schemaVersion: typeof STRATAGATE_STORAGE_SCHEMA_VERSION;
+  currentTurn: number;
+  blockTurnSize: number;
+  openTail: RawMessage[];
+  blocks: MemoryBlock[];
+  events: EventCard[];
+  extractionJobs: ExtractionJob[];
+  usageReceipts: UsageReceipt[];
+}
+
+export interface LoadedStrataGateState {
+  snapshot: StrataGateSnapshot;
+  revision: number;
+}
+
+export interface StorageAdapter {
+  load(namespace: string): Promise<LoadedStrataGateState | null>;
+  save(namespace: string, snapshot: StrataGateSnapshot, expectedRevision: number): Promise<number>;
+  close?(): Promise<void>;
+}
+
+export class StorageConflictError extends Error {
+  constructor(
+    readonly namespace: string,
+    readonly expectedRevision: number,
+    readonly actualRevision: number | null,
+  ) {
+    super(`Storage revision conflict for ${namespace}: expected ${expectedRevision}, found ${actualRevision ?? 'missing'}`);
+    this.name = 'StorageConflictError';
+  }
+}
+
+export function cloneSnapshot(snapshot: StrataGateSnapshot): StrataGateSnapshot {
+  return structuredClone(snapshot);
+}
+
+export function assertValidSnapshot(value: unknown): asserts value is StrataGateSnapshot {
+  if (!value || typeof value !== 'object') throw new TypeError('Invalid StrataGate snapshot: expected an object');
+  const snapshot = value as Partial<StrataGateSnapshot>;
+  if (snapshot.schemaVersion !== STRATAGATE_STORAGE_SCHEMA_VERSION) {
+    throw new TypeError(`Unsupported StrataGate snapshot schema: ${String(snapshot.schemaVersion)}`);
+  }
+  if (!Number.isSafeInteger(snapshot.currentTurn) || (snapshot.currentTurn ?? -1) < 0) {
+    throw new TypeError('Invalid StrataGate snapshot: currentTurn must be a non-negative integer');
+  }
+  if (!Number.isSafeInteger(snapshot.blockTurnSize) || (snapshot.blockTurnSize ?? 0) < 1) {
+    throw new TypeError('Invalid StrataGate snapshot: blockTurnSize must be a positive integer');
+  }
+  for (const key of ['openTail', 'blocks', 'events', 'extractionJobs', 'usageReceipts'] as const) {
+    if (!Array.isArray(snapshot[key])) throw new TypeError(`Invalid StrataGate snapshot: ${key} must be an array`);
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,15 @@ import {
   normalizeBlockLevel,
 } from './blocks.js';
 import { normalizeRetrievalAssessment, type RetrievalAssessment, type RetrievalAssessmentInput } from './retrieval.js';
+import {
+  STRATAGATE_STORAGE_SCHEMA_VERSION,
+  assertValidSnapshot,
+  cloneSnapshot,
+  type ExtractionJob,
+  type StorageAdapter,
+  type StrataGateSnapshot,
+  type UsageReceipt,
+} from './storage.js';
 import type {
   AppendTurnResult,
   BlockLevel,
@@ -30,6 +39,11 @@ export interface StrataGateOptions {
   idFactory?: (prefix: 'msg' | 'blk' | 'evt') => string;
 }
 
+export interface PersistentStrataGateOptions extends StrataGateOptions {
+  storage: StorageAdapter;
+  namespace: string;
+}
+
 export interface TurnInput {
   user: string;
   assistant: string;
@@ -44,6 +58,15 @@ export interface BlockContextEntry {
   level: BlockLevel;
   label: string;
   content: string;
+}
+
+export interface RecordMemoryUseOptions {
+  receiptId?: string;
+}
+
+export interface ResumePendingResult {
+  sealedBlocks: MemoryBlock[];
+  extractedEvents: EventCard[];
 }
 
 function defaultIdFactory(prefix: 'msg' | 'blk' | 'evt'): string {
@@ -89,6 +112,14 @@ function renderBlock(block: MemoryBlock, level: BlockLevel): string {
   return block.l5Raw.map((message) => `${message.role}: ${message.content}`).join('\n\n');
 }
 
+function sameIds(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((id, index) => id === right[index]);
+}
+
+function errorMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, 1_000);
+}
+
 export class StrataGate {
   readonly blockTurnSize: number;
 
@@ -99,8 +130,13 @@ export class StrataGate {
   private readonly openTail: RawMessage[] = [];
   private readonly blocks: MemoryBlock[] = [];
   private readonly events: EventCard[] = [];
-  private readonly extractedBlockIds = new Set<string>();
+  private readonly extractionJobs = new Map<string, ExtractionJob>();
+  private readonly usageReceipts = new Map<string, UsageReceipt>();
   private currentTurn = 0;
+  private storage: StorageAdapter | undefined;
+  private namespace: string | undefined;
+  private revision = 0;
+  private mutationQueue: Promise<void> = Promise.resolve();
 
   constructor(options: StrataGateOptions = {}) {
     this.blockTurnSize = Math.max(1, Math.floor(options.blockTurnSize ?? DEFAULT_BLOCK_TURN_SIZE));
@@ -110,8 +146,55 @@ export class StrataGate {
     this.idFactory = options.idFactory ?? defaultIdFactory;
   }
 
+  static async open(options: PersistentStrataGateOptions): Promise<StrataGate> {
+    const namespace = options.namespace.trim();
+    if (!namespace) throw new TypeError('Storage namespace must not be empty');
+    const loaded = await options.storage.load(namespace);
+    if (loaded && options.blockTurnSize !== undefined) {
+      const requested = Math.max(1, Math.floor(options.blockTurnSize));
+      if (requested !== loaded.snapshot.blockTurnSize) {
+        throw new Error(`Stored blockTurnSize is ${loaded.snapshot.blockTurnSize}, but ${requested} was requested`);
+      }
+    }
+    const memoryOptions: StrataGateOptions = {};
+    if (loaded) memoryOptions.blockTurnSize = loaded.snapshot.blockTurnSize;
+    else if (options.blockTurnSize !== undefined) memoryOptions.blockTurnSize = options.blockTurnSize;
+    if (options.summarizer) memoryOptions.summarizer = options.summarizer;
+    if (options.extractor) memoryOptions.extractor = options.extractor;
+    if (options.now) memoryOptions.now = options.now;
+    if (options.idFactory) memoryOptions.idFactory = options.idFactory;
+    const memory = new StrataGate(memoryOptions);
+    memory.storage = options.storage;
+    memory.namespace = namespace;
+    if (loaded) {
+      memory.restoreSnapshot(loaded.snapshot);
+      memory.revision = loaded.revision;
+      const interrupted = [...memory.extractionJobs.values()].filter((job) => job.status === 'running');
+      if (interrupted.length > 0) {
+        await memory.commitMutation(() => {
+          const now = memory.now().toISOString();
+          for (const job of interrupted) {
+            memory.extractionJobs.set(job.blockId, {
+              ...job,
+              status: 'failed',
+              lastError: 'Extraction was interrupted before completion.',
+              updatedAt: now,
+            });
+          }
+        });
+      }
+    } else {
+      await memory.persist();
+    }
+    return memory;
+  }
+
   get turn(): number {
     return this.currentTurn;
+  }
+
+  get storageRevision(): number {
+    return this.revision;
   }
 
   listBlocks(): readonly MemoryBlock[] {
@@ -126,87 +209,76 @@ export class StrataGate {
     return this.openTail;
   }
 
+  listExtractionJobs(): readonly ExtractionJob[] {
+    return [...this.extractionJobs.values()];
+  }
+
+  exportSnapshot(): StrataGateSnapshot {
+    return cloneSnapshot({
+      schemaVersion: STRATAGATE_STORAGE_SCHEMA_VERSION,
+      currentTurn: this.currentTurn,
+      blockTurnSize: this.blockTurnSize,
+      openTail: this.openTail,
+      blocks: this.blocks,
+      events: this.events,
+      extractionJobs: [...this.extractionJobs.values()],
+      usageReceipts: [...this.usageReceipts.values()],
+    });
+  }
+
   async appendTurn(input: TurnInput): Promise<AppendTurnResult> {
-    this.currentTurn += 1;
     const createdAt = input.createdAt ?? this.now().toISOString();
-    this.openTail.push(
-      {
-        id: this.idFactory('msg'),
-        role: 'user',
-        content: input.user,
-        createdAt,
-        ...(input.userToolCalls ? { toolCalls: input.userToolCalls } : {}),
-      },
-      {
-        id: this.idFactory('msg'),
-        role: 'assistant',
-        content: input.assistant,
-        createdAt,
-        ...(input.assistantToolCalls ? { toolCalls: input.assistantToolCalls } : {}),
-      },
-    );
+    const userMessage: RawMessage = {
+      id: this.idFactory('msg'),
+      role: 'user',
+      content: input.user,
+      createdAt,
+      ...(input.userToolCalls ? { toolCalls: input.userToolCalls } : {}),
+    };
+    const assistantMessage: RawMessage = {
+      id: this.idFactory('msg'),
+      role: 'assistant',
+      content: input.assistant,
+      createdAt,
+      ...(input.assistantToolCalls ? { toolCalls: input.assistantToolCalls } : {}),
+    };
+    await this.commitMutation(() => {
+      this.currentTurn += 1;
+      this.openTail.push(userMessage, assistantMessage);
+    });
 
     if (this.openTail.filter((message) => message.role === 'user').length < this.blockTurnSize) {
       return { sealedBlock: null, extractedEvents: [] };
     }
 
     const sealedBlock = await this.sealOpenTail();
-    const extractedEvents = await this.extractEligibleBlock();
+    const extractedEvents = await this.extractEligibleBlock() ?? [];
     return { sealedBlock, extractedEvents };
   }
 
-  addEvent(input: EventCardInput): EventCard {
-    const sourceBlock = this.blocks.find((block) => block.id === input.sourceBlockId);
-    if (!sourceBlock) throw new Error(`Unknown source block: ${input.sourceBlockId}`);
-    const validIds = new Set(sourceBlock.l5Raw.map((message) => message.id));
-    const requestedRefs = [...new Set(input.sourceMessageIds.filter((id) => validIds.has(id)))];
-    const sourceMessageIds = requestedRefs.length > 0 ? requestedRefs : sourceBlock.l5Raw.map((message) => message.id);
-    const now = this.now().toISOString();
-    const criticality = input.criticality ?? 'routine';
-    const event: EventCard = {
-      id: input.id ?? this.idFactory('evt'),
-      title: input.title.trim(),
-      summary: input.summary.trim(),
-      narrative: input.narrative?.trim() || input.summary.trim(),
-      tags: [...new Set(input.tags ?? [])].slice(0, 12),
-      quotes: [...new Set(input.quotes ?? [])].slice(0, 12),
-      sourceMessageIds,
-      sourceBlockId: sourceBlock.id,
-      temporal: input.temporal ? { ...input.temporal } : { mentionedAt: now },
-      scope: input.scope ?? 'user',
-      criticality,
-      confidence: Math.max(0, Math.min(1, input.confidence ?? 1)),
-      status: 'active',
-      supersededBy: null,
-      weight: {
-        mentionCount: 1,
-        lastAdoptedTurn: this.currentTurn,
-        lastRetrievedAt: null,
-        pinned: false,
-        floorWeight: criticalityFloor(criticality),
-        forcedCap: null,
-      },
-      createdAt: now,
-      updatedAt: now,
-    };
-    this.events.push(event);
-
-    for (const supersededId of event.temporal.supersedesEventIds ?? []) {
-      const old = this.events.find((candidate) => candidate.id === supersededId && candidate.id !== event.id);
-      if (!old) continue;
-      old.status = 'superseded';
-      old.supersededBy = event.id;
-      old.weight.forcedCap = 0.1;
-      old.updatedAt = now;
+  async resumePendingWork(): Promise<ResumePendingResult> {
+    const sealedBlocks: MemoryBlock[] = [];
+    const extractedEvents: EventCard[] = [];
+    while (this.openTail.filter((message) => message.role === 'user').length >= this.blockTurnSize) {
+      sealedBlocks.push(await this.sealOpenTail());
+      extractedEvents.push(...(await this.extractEligibleBlock() ?? []));
     }
-    return event;
+    while (true) {
+      const extracted = await this.extractEligibleBlock();
+      if (extracted === null) break;
+      extractedEvents.push(...extracted);
+    }
+    return { sealedBlocks, extractedEvents };
   }
 
-  searchEvents(query: string, options: SearchOptions = {}): EventSearchResult[] {
+  async addEvent(input: EventCardInput): Promise<EventCard> {
+    return this.commitMutation(() => this.addEventInMemory(input));
+  }
+
+  async searchEvents(query: string, options: SearchOptions = {}): Promise<EventSearchResult[]> {
     const tokens = queryTokens(query);
     const participants = (options.participants ?? []).map(normalizeText);
     const eventType = options.eventType ? normalizeText(options.eventType) : null;
-    const now = this.now().toISOString();
     const ranked = this.events
       .filter((event) => event.status === 'active' || event.status === 'superseded')
       .filter((event) => participants.length === 0 || participants.every((person) =>
@@ -237,9 +309,14 @@ export class StrataGate {
       .sort((a, b) => b.score - a.score)
       .slice(0, Math.max(1, Math.min(20, options.limit ?? 6)));
 
-    for (const { event } of ranked) event.weight.lastRetrievedAt = now;
     if (options.temporalIntent) {
       ranked.sort((a, b) => (a.event.temporal.happenedStart ?? '').localeCompare(b.event.temporal.happenedStart ?? ''));
+    }
+    if (ranked.length > 0) {
+      const now = this.now().toISOString();
+      await this.commitMutation(() => {
+        for (const { event } of ranked) event.weight.lastRetrievedAt = now;
+      });
     }
     return ranked;
   }
@@ -278,55 +355,131 @@ export class StrataGate {
     });
   }
 
-  expandBlock(id: string, target: unknown = 'next'): BlockContextEntry {
-    const block = this.blocks.find((candidate) => candidate.id === id);
-    if (!block) throw new Error(`Unknown block: ${id}`);
-    const current = getDecayedBlockLevel(block.pointerAnchorLevel, block.pointerAnchorTurn, this.currentTurn);
-    const level = normalizeBlockLevel(target, current);
-    block.pointerCurrentLevel = level;
-    block.pointerAnchorLevel = level;
-    block.pointerAnchorTurn = this.currentTurn;
-    block.lastLiftedAt = this.now().toISOString();
-    return {
-      id: block.id,
-      turnRange: [block.startTurn, block.endTurn],
-      level,
-      label: blockLevelLabel(level),
-      content: renderBlock(block, level),
-    };
+  async expandBlock(id: string, target: unknown = 'next'): Promise<BlockContextEntry> {
+    return this.commitMutation(() => {
+      const block = this.blocks.find((candidate) => candidate.id === id);
+      if (!block) throw new Error(`Unknown block: ${id}`);
+      const current = getDecayedBlockLevel(block.pointerAnchorLevel, block.pointerAnchorTurn, this.currentTurn);
+      const level = normalizeBlockLevel(target, current);
+      block.pointerCurrentLevel = level;
+      block.pointerAnchorLevel = level;
+      block.pointerAnchorTurn = this.currentTurn;
+      block.lastLiftedAt = this.now().toISOString();
+      return {
+        id: block.id,
+        turnRange: [block.startTurn, block.endTurn] as [number, number],
+        level,
+        label: blockLevelLabel(level),
+        content: renderBlock(block, level),
+      };
+    });
   }
 
   assessRetrieval(input: RetrievalAssessmentInput, latestEvidenceRefs: ReadonlySet<string>): RetrievalAssessment {
     return normalizeRetrievalAssessment(input, latestEvidenceRefs);
   }
 
-  recordMemoryUse(eventIds: readonly string[]): void {
-    const now = this.now().toISOString();
-    for (const id of new Set(eventIds)) {
-      const event = this.events.find((candidate) => candidate.id === id);
-      if (!event || event.status === 'forgotten' || event.status === 'archived') continue;
-      event.weight.mentionCount += 1;
-      event.weight.lastAdoptedTurn = this.currentTurn;
-      event.updatedAt = now;
+  async recordMemoryUse(eventIds: readonly string[], options: RecordMemoryUseOptions = {}): Promise<void> {
+    const receiptId = options.receiptId?.trim();
+    if (this.storage && !receiptId) throw new TypeError('Persistent recordMemoryUse requires a non-empty receiptId');
+    const requestedIds = [...new Set(eventIds)];
+    if (receiptId) {
+      const existing = this.usageReceipts.get(receiptId);
+      if (existing) {
+        if (!sameIds(existing.eventIds, requestedIds)) {
+          throw new Error(`Usage receipt ${receiptId} was already recorded with different event IDs`);
+        }
+        return;
+      }
     }
+
+    await this.commitMutation(() => {
+      const now = this.now().toISOString();
+      for (const id of requestedIds) {
+        const event = this.events.find((candidate) => candidate.id === id);
+        if (!event || event.status === 'forgotten' || event.status === 'archived') continue;
+        event.weight.mentionCount += 1;
+        event.weight.lastAdoptedTurn = this.currentTurn;
+        event.updatedAt = now;
+      }
+      if (receiptId) this.usageReceipts.set(receiptId, { id: receiptId, eventIds: requestedIds, createdAt: now });
+    });
   }
 
-  pinEvent(id: string, pinned = true): void {
-    const event = this.requireEvent(id);
-    event.weight.pinned = pinned;
-    event.updatedAt = this.now().toISOString();
+  async pinEvent(id: string, pinned = true): Promise<void> {
+    await this.commitMutation(() => {
+      const event = this.requireEvent(id);
+      event.weight.pinned = pinned;
+      event.updatedAt = this.now().toISOString();
+    });
   }
 
-  forgetEvent(id: string): void {
-    const event = this.requireEvent(id);
-    event.status = 'forgotten';
-    event.updatedAt = this.now().toISOString();
+  async forgetEvent(id: string): Promise<void> {
+    await this.commitMutation(() => {
+      const event = this.requireEvent(id);
+      event.status = 'forgotten';
+      event.updatedAt = this.now().toISOString();
+    });
   }
 
-  restoreEvent(id: string): void {
-    const event = this.requireEvent(id);
-    event.status = 'active';
-    event.updatedAt = this.now().toISOString();
+  async restoreEvent(id: string): Promise<void> {
+    await this.commitMutation(() => {
+      const event = this.requireEvent(id);
+      event.status = 'active';
+      event.updatedAt = this.now().toISOString();
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.storage?.close?.();
+  }
+
+  private addEventInMemory(input: EventCardInput): EventCard {
+    const sourceBlock = this.blocks.find((block) => block.id === input.sourceBlockId);
+    if (!sourceBlock) throw new Error(`Unknown source block: ${input.sourceBlockId}`);
+    const validIds = new Set(sourceBlock.l5Raw.map((message) => message.id));
+    const requestedRefs = [...new Set(input.sourceMessageIds.filter((id) => validIds.has(id)))];
+    const sourceMessageIds = requestedRefs.length > 0 ? requestedRefs : sourceBlock.l5Raw.map((message) => message.id);
+    const now = this.now().toISOString();
+    const criticality = input.criticality ?? 'routine';
+    const event: EventCard = {
+      id: input.id ?? this.idFactory('evt'),
+      title: input.title.trim(),
+      summary: input.summary.trim(),
+      narrative: input.narrative?.trim() || input.summary.trim(),
+      tags: [...new Set(input.tags ?? [])].slice(0, 12),
+      quotes: [...new Set(input.quotes ?? [])].slice(0, 12),
+      sourceMessageIds,
+      sourceBlockId: sourceBlock.id,
+      temporal: input.temporal ? { ...input.temporal } : { mentionedAt: now },
+      scope: input.scope ?? 'user',
+      criticality,
+      confidence: Math.max(0, Math.min(1, input.confidence ?? 1)),
+      status: 'active',
+      supersededBy: null,
+      weight: {
+        mentionCount: 1,
+        lastAdoptedTurn: this.currentTurn,
+        lastRetrievedAt: null,
+        pinned: false,
+        floorWeight: criticalityFloor(criticality),
+        forcedCap: null,
+      },
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (this.events.some((candidate) => candidate.id === event.id)) throw new Error(`Duplicate event ID: ${event.id}`);
+    this.events.push(event);
+
+    for (const supersededId of event.temporal.supersedesEventIds ?? []) {
+      const old = this.events.find((candidate) => candidate.id === supersededId && candidate.id !== event.id);
+      if (!old) continue;
+      old.status = 'superseded';
+      old.supersededBy = event.id;
+      old.weight.forcedCap = 0.1;
+      old.updatedAt = now;
+    }
+    return event;
   }
 
   private requireEvent(id: string): EventCard {
@@ -335,48 +488,202 @@ export class StrataGate {
     return event;
   }
 
+  private pendingBlockMessages(): RawMessage[] {
+    let users = 0;
+    let end = this.openTail.length;
+    for (const [index, message] of this.openTail.entries()) {
+      if (message.role !== 'user') continue;
+      users += 1;
+      if (users !== this.blockTurnSize) continue;
+      const nextUserOffset = this.openTail.slice(index + 1).findIndex((candidate) => candidate.role === 'user');
+      end = nextUserOffset === -1 ? this.openTail.length : index + 1 + nextUserOffset;
+      break;
+    }
+    return this.openTail.slice(0, end);
+  }
+
   private async sealOpenTail(): Promise<MemoryBlock> {
-    const raw = this.openTail.splice(0, this.openTail.length);
+    const raw = this.pendingBlockMessages();
+    if (raw.filter((message) => message.role === 'user').length < this.blockTurnSize) {
+      throw new Error('Open tail does not contain enough turns to seal a block');
+    }
     const generated = this.summarizer ? await this.summarizer(raw) : defaultSummary(raw);
     const deterministic = deterministicBlockLayers(raw);
     const sequence = this.blocks.length + 1;
-    const endTurn = this.currentTurn;
-    const block: MemoryBlock = {
-      id: this.idFactory('blk'),
-      sequence,
-      startTurn: endTurn - this.blockTurnSize + 1,
-      endTurn,
-      createdAt: raw.at(-1)?.createdAt ?? this.now().toISOString(),
-      l0Title: generated.l0Title,
-      l0Tags: generated.l0Tags,
-      l1Summary: generated.l1Summary,
-      l2Keypoints: generated.l2Keypoints,
-      shouldExtract: generated.shouldExtract,
-      ...deterministic,
-      pointerCurrentLevel: 5,
-      pointerAnchorLevel: 5,
-      pointerAnchorTurn: endTurn,
-      lastLiftedAt: null,
-    };
-    this.blocks.push(block);
-    return block;
+    const startTurn = this.blocks.at(-1)?.endTurn !== undefined ? (this.blocks.at(-1)?.endTurn ?? 0) + 1 : 1;
+    const endTurn = startTurn + this.blockTurnSize - 1;
+    return this.commitMutation(() => {
+      const currentRaw = this.pendingBlockMessages();
+      if (!sameIds(currentRaw.map((message) => message.id), raw.map((message) => message.id))) {
+        throw new Error('Open tail changed while the block summary was being prepared');
+      }
+      const block: MemoryBlock = {
+        id: this.idFactory('blk'),
+        sequence,
+        startTurn,
+        endTurn,
+        createdAt: raw.at(-1)?.createdAt ?? this.now().toISOString(),
+        l0Title: generated.l0Title,
+        l0Tags: generated.l0Tags,
+        l1Summary: generated.l1Summary,
+        l2Keypoints: generated.l2Keypoints,
+        shouldExtract: generated.shouldExtract,
+        ...deterministic,
+        pointerCurrentLevel: 5,
+        pointerAnchorLevel: 5,
+        pointerAnchorTurn: endTurn,
+        lastLiftedAt: null,
+      };
+      this.openTail.splice(0, raw.length);
+      this.blocks.push(block);
+      return block;
+    });
   }
 
-  private async extractEligibleBlock(): Promise<EventCard[]> {
-    if (!this.extractor || this.blocks.length < 2) return [];
-    const targetIndex = this.blocks.length - 2;
+  private async extractEligibleBlock(): Promise<EventCard[] | null> {
+    if (!this.extractor || this.blocks.length < 2) return null;
+    const targetIndex = this.blocks.findIndex((block, index) => {
+      if (index >= this.blocks.length - 1 || !block.shouldExtract) return false;
+      const status = this.extractionJobs.get(block.id)?.status;
+      return status === undefined || status === 'failed';
+    });
+    if (targetIndex < 0) return null;
     const target = this.blocks[targetIndex];
     const next = this.blocks[targetIndex + 1];
-    if (!target || !next || !target.shouldExtract || this.extractedBlockIds.has(target.id)) return [];
-    this.extractedBlockIds.add(target.id);
-    const previous = this.blocks[targetIndex - 1] ?? null;
-    const result = await this.extractor({
-      previous,
-      target,
-      next,
-      timeline: this.events.map((event) => ({ id: event.id, title: event.title, temporal: event.temporal })),
+    if (!target || !next) return null;
+    const existing = this.extractionJobs.get(target.id);
+    await this.commitMutation(() => {
+      const currentStatus = this.extractionJobs.get(target.id)?.status;
+      if (currentStatus !== undefined && currentStatus !== 'failed') {
+        throw new Error(`Extraction block ${target.id} is already ${currentStatus}`);
+      }
+      this.extractionJobs.set(target.id, {
+        blockId: target.id,
+        status: 'running',
+        attempts: (existing?.attempts ?? 0) + 1,
+        lastError: null,
+        updatedAt: this.now().toISOString(),
+      });
     });
-    if (!result.shouldExtract) return [];
-    return result.events.map((event) => this.addEvent({ ...event, sourceBlockId: target.id }));
+
+    let result: Awaited<ReturnType<EventExtractor>>;
+    try {
+      result = await this.extractor({
+        previous: this.blocks[targetIndex - 1] ?? null,
+        target,
+        next,
+        timeline: this.events.map((event) => ({ id: event.id, title: event.title, temporal: event.temporal })),
+      });
+    } catch (error) {
+      await this.commitMutation(() => {
+        const job = this.extractionJobs.get(target.id);
+        if (!job) return;
+        this.extractionJobs.set(target.id, {
+          ...job,
+          status: 'failed',
+          lastError: errorMessage(error),
+          updatedAt: this.now().toISOString(),
+        });
+      });
+      throw error;
+    }
+
+    return this.commitMutation(() => {
+      const extracted = result.shouldExtract
+        ? result.events.map((event) => this.addEventInMemory({ ...event, sourceBlockId: target.id }))
+        : [];
+      const job = this.extractionJobs.get(target.id);
+      if (!job) throw new Error(`Missing extraction job for block: ${target.id}`);
+      this.extractionJobs.set(target.id, {
+        ...job,
+        status: result.shouldExtract ? 'succeeded' : 'skipped',
+        lastError: null,
+        updatedAt: this.now().toISOString(),
+      });
+      return extracted;
+    });
+  }
+
+  private async commitMutation<T>(mutation: () => T | Promise<T>): Promise<T> {
+    const previous = this.mutationQueue;
+    let release!: () => void;
+    this.mutationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    if (!this.storage) {
+      try {
+        return await mutation();
+      } finally {
+        release();
+      }
+    }
+
+    const before = this.exportSnapshot();
+    const beforeRevision = this.revision;
+    try {
+      const result = await mutation();
+      await this.persist();
+      return result;
+    } catch (error) {
+      this.restoreSnapshot(before);
+      this.revision = beforeRevision;
+      throw error;
+    } finally {
+      release();
+    }
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.storage || !this.namespace) return;
+    this.revision = await this.storage.save(this.namespace, this.exportSnapshot(), this.revision);
+  }
+
+  private restoreSnapshot(snapshot: StrataGateSnapshot): void {
+    assertValidSnapshot(snapshot);
+    if (snapshot.blockTurnSize !== this.blockTurnSize) {
+      throw new Error(`Snapshot blockTurnSize ${snapshot.blockTurnSize} does not match ${this.blockTurnSize}`);
+    }
+    const copy = cloneSnapshot(snapshot);
+    this.currentTurn = copy.currentTurn;
+    this.openTail.splice(0, this.openTail.length, ...copy.openTail);
+    this.blocks.splice(0, this.blocks.length, ...copy.blocks);
+    this.events.splice(0, this.events.length, ...copy.events);
+    this.extractionJobs.clear();
+    for (const job of copy.extractionJobs) this.extractionJobs.set(job.blockId, job);
+    this.usageReceipts.clear();
+    for (const receipt of copy.usageReceipts) this.usageReceipts.set(receipt.id, receipt);
+    this.validateReferences();
+  }
+
+  private validateReferences(): void {
+    const blockIds = new Set<string>();
+    const messageBlockIds = new Map<string, string>();
+    for (const block of this.blocks) {
+      if (blockIds.has(block.id)) throw new Error(`Duplicate block ID in snapshot: ${block.id}`);
+      blockIds.add(block.id);
+      for (const message of block.l5Raw) {
+        if (messageBlockIds.has(message.id)) throw new Error(`Duplicate message ID in snapshot: ${message.id}`);
+        messageBlockIds.set(message.id, block.id);
+      }
+    }
+    for (const message of this.openTail) {
+      if (messageBlockIds.has(message.id)) throw new Error(`Duplicate message ID in snapshot: ${message.id}`);
+      messageBlockIds.set(message.id, 'open-tail');
+    }
+    const eventIds = new Set<string>();
+    for (const event of this.events) {
+      if (eventIds.has(event.id)) throw new Error(`Duplicate event ID in snapshot: ${event.id}`);
+      eventIds.add(event.id);
+      if (!blockIds.has(event.sourceBlockId)) throw new Error(`Unknown event source block in snapshot: ${event.sourceBlockId}`);
+      for (const messageId of event.sourceMessageIds) {
+        if (messageBlockIds.get(messageId) !== event.sourceBlockId) {
+          throw new Error(`Event ${event.id} references a message outside source block ${event.sourceBlockId}`);
+        }
+      }
+    }
+    for (const job of this.extractionJobs.values()) {
+      if (!blockIds.has(job.blockId)) throw new Error(`Unknown extraction job block in snapshot: ${job.blockId}`);
+    }
   }
 }

--- a/tests/persistence.test.ts
+++ b/tests/persistence.test.ts
@@ -1,0 +1,260 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  StorageConflictError,
+  StrataGate,
+  type BlockSummarizer,
+  type EventExtractor,
+} from '../src/index.js';
+import { SqliteStorage } from '../src/sqlite.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+async function databasePath(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'stratagate-'));
+  temporaryDirectories.push(directory);
+  return join(directory, 'memory.db');
+}
+
+function ids(): (prefix: 'msg' | 'blk' | 'evt') => string {
+  let value = 0;
+  return (prefix) => `${prefix}_${++value}`;
+}
+
+const fixedNow = (): Date => new Date('2026-08-12T00:00:00.000Z');
+
+const summarizer: BlockSummarizer = async (messages) => ({
+  l0Title: messages[0]?.content ?? 'block',
+  l0Tags: ['persistent'],
+  l1Summary: messages.map((message) => message.content).join(' '),
+  l2Keypoints: messages.map((message) => message.content),
+  shouldExtract: true,
+});
+
+const extractor: EventExtractor = async ({ target }) => ({
+  shouldExtract: true,
+  reason: 'durable preference',
+  events: [{
+    id: `event_for_${target.id}`,
+    title: 'Persistent preference',
+    summary: target.l5Raw[0]?.content ?? 'preference',
+    sourceMessageIds: [target.l5Raw[0]?.id ?? 'missing'],
+    sourceBlockId: target.id,
+    criticality: 'preference',
+  }],
+});
+
+describe('SQLite persistence', () => {
+  it('creates schema version one and rejects a newer database schema', async () => {
+    const initializedFilename = await databasePath();
+    const initialized = new SqliteStorage({ filename: initializedFilename });
+    await initialized.close();
+    const initializedDatabase = new Database(initializedFilename, { readonly: true });
+    expect(initializedDatabase.pragma('user_version', { simple: true })).toBe(1);
+    initializedDatabase.close();
+
+    const newerFilename = await databasePath();
+    const newerDatabase = new Database(newerFilename);
+    newerDatabase.pragma('user_version = 2');
+    newerDatabase.close();
+    expect(() => new SqliteStorage({ filename: newerFilename })).toThrow('newer than supported');
+  });
+
+  it('restores an open tail and seals it at the same boundary after restart', async () => {
+    const filename = await databasePath();
+    const idFactory = ids();
+    const first = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'user:alice',
+      blockTurnSize: 2,
+      summarizer,
+      idFactory,
+      now: fixedNow,
+    });
+    await first.appendTurn({ user: 'turn one', assistant: 'answer one' });
+    expect(first.listOpenTail()).toHaveLength(2);
+    await first.close();
+
+    const second = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'user:alice',
+      summarizer,
+      idFactory,
+      now: fixedNow,
+    });
+    expect(second.turn).toBe(1);
+    expect(second.listOpenTail().map((message) => message.content)).toEqual(['turn one', 'answer one']);
+    const result = await second.appendTurn({ user: 'turn two', assistant: 'answer two' });
+    expect(result.sealedBlock?.startTurn).toBe(1);
+    expect(result.sealedBlock?.endTurn).toBe(2);
+    expect(second.listOpenTail()).toHaveLength(0);
+    const expected = second.exportSnapshot();
+    await second.close();
+
+    const restored = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'user:alice',
+      summarizer,
+      idFactory,
+      now: fixedNow,
+    });
+    expect(restored.exportSnapshot()).toEqual(expected);
+    await restored.close();
+  });
+
+  it('keeps raw turns durable when summarization fails and resumes without appending again', async () => {
+    const filename = await databasePath();
+    const failingSummary: BlockSummarizer = async () => {
+      throw new Error('summary unavailable');
+    };
+    const first = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'session:summary-retry',
+      blockTurnSize: 1,
+      summarizer: failingSummary,
+      now: fixedNow,
+      idFactory: ids(),
+    });
+    await expect(first.appendTurn({ user: 'must survive', assistant: 'stored first' }))
+      .rejects.toThrow('summary unavailable');
+    expect(first.turn).toBe(1);
+    expect(first.listOpenTail()).toHaveLength(2);
+    expect(first.listBlocks()).toHaveLength(0);
+    await first.close();
+
+    const restored = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'session:summary-retry',
+      summarizer,
+      now: fixedNow,
+      idFactory: ids(),
+    });
+    const resumed = await restored.resumePendingWork();
+    expect(resumed.sealedBlocks).toHaveLength(1);
+    expect(restored.listBlocks()[0]?.l5Raw[0]?.content).toBe('must survive');
+    expect(restored.turn).toBe(1);
+    await restored.close();
+  });
+
+  it('persists failed extraction and retries only that eligible block', async () => {
+    const filename = await databasePath();
+    let attempts = 0;
+    const failingExtractor: EventExtractor = async () => {
+      attempts += 1;
+      throw new Error('extractor unavailable');
+    };
+    const idFactory = ids();
+    const first = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'session:extract-retry',
+      blockTurnSize: 1,
+      summarizer,
+      extractor: failingExtractor,
+      now: fixedNow,
+      idFactory,
+    });
+    await first.appendTurn({ user: 'remember this', assistant: 'okay' });
+    await expect(first.appendTurn({ user: 'later context', assistant: 'noted' }))
+      .rejects.toThrow('extractor unavailable');
+    expect(attempts).toBe(1);
+    expect(first.listBlocks()).toHaveLength(2);
+    expect(first.listEvents()).toHaveLength(0);
+    expect(first.listExtractionJobs()).toMatchObject([{
+      status: 'failed',
+      attempts: 1,
+      lastError: 'extractor unavailable',
+    }]);
+    await first.close();
+
+    const restored = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'session:extract-retry',
+      summarizer,
+      extractor,
+      now: fixedNow,
+      idFactory,
+    });
+    const resumed = await restored.resumePendingWork();
+    expect(resumed.extractedEvents).toHaveLength(1);
+    expect(restored.listEvents()).toHaveLength(1);
+    expect(restored.listExtractionJobs()).toMatchObject([{
+      status: 'succeeded',
+      attempts: 2,
+      lastError: null,
+    }]);
+    await restored.close();
+  });
+
+  it('makes adoption receipts idempotent across retries and restarts', async () => {
+    const filename = await databasePath();
+    const idFactory = ids();
+    const first = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'user:receipts',
+      blockTurnSize: 1,
+      summarizer,
+      extractor,
+      now: fixedNow,
+      idFactory,
+    });
+    await first.appendTurn({ user: 'prefer short answers', assistant: 'okay' });
+    await first.appendTurn({ user: 'what is my preference?', assistant: 'checking' });
+    const event = first.listEvents()[0];
+    expect(event).toBeDefined();
+    if (!event) return;
+    await first.recordMemoryUse([event.id], { receiptId: 'answer:42' });
+    await first.recordMemoryUse([event.id], { receiptId: 'answer:42' });
+    expect(event.weight.mentionCount).toBe(2);
+    await first.close();
+
+    const restored = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'user:receipts',
+      summarizer,
+      extractor,
+      now: fixedNow,
+      idFactory,
+    });
+    const restoredEvent = restored.listEvents()[0];
+    expect(restoredEvent?.weight.mentionCount).toBe(2);
+    if (restoredEvent) {
+      await restored.recordMemoryUse([restoredEvent.id], { receiptId: 'answer:42' });
+      expect(restoredEvent.weight.mentionCount).toBe(2);
+      await expect(restored.recordMemoryUse([], { receiptId: 'answer:42' }))
+        .rejects.toThrow('different event IDs');
+    }
+    await restored.close();
+  });
+
+  it('rejects a stale writer and rolls back its in-memory mutation', async () => {
+    const filename = await databasePath();
+    const first = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'project:shared',
+      blockTurnSize: 12,
+      now: fixedNow,
+      idFactory: ids(),
+    });
+    const stale = await StrataGate.open({
+      storage: new SqliteStorage({ filename }),
+      namespace: 'project:shared',
+      now: fixedNow,
+      idFactory: ids(),
+    });
+
+    await first.appendTurn({ user: 'writer one', assistant: 'committed' });
+    await expect(stale.appendTurn({ user: 'writer two', assistant: 'stale' }))
+      .rejects.toBeInstanceOf(StorageConflictError);
+    expect(stale.turn).toBe(0);
+    expect(stale.listOpenTail()).toHaveLength(0);
+    await first.close();
+    await stale.close();
+  });
+});

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -38,16 +38,16 @@ describe('StrataGate lifecycle', () => {
 
     const second = await memory.appendTurn({ user: 'What did I ask?', assistant: 'Let me check.' });
     expect(second.extractedEvents).toHaveLength(1);
-    const result = memory.searchEvents('concise writing preference');
+    const result = await memory.searchEvents('concise writing preference');
     expect(result[0]?.event.title).toBe('Prefers concise answers');
 
     const event = result[0]?.event;
     expect(event).toBeDefined();
     if (!event) return;
     const before = event.weight.mentionCount;
-    memory.searchEvents('concise');
+    await memory.searchEvents('concise');
     expect(event.weight.mentionCount).toBe(before);
-    memory.recordMemoryUse([event.id]);
+    await memory.recordMemoryUse([event.id]);
     expect(event.weight.mentionCount).toBe(before + 1);
     expect(memoryWeightAt(event, memory.turn)).toBe(1);
   });
@@ -59,8 +59,8 @@ describe('StrataGate lifecycle', () => {
     const event = memory.listEvents()[0];
     expect(event).toBeDefined();
     if (!event) return;
-    memory.forgetEvent(event.id);
-    expect(memory.searchEvents('concise')).toHaveLength(0);
+    await memory.forgetEvent(event.id);
+    expect(await memory.searchEvents('concise')).toHaveLength(0);
     expect(memory.listEvents()[0]?.sourceMessageIds.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What changed

- add a versioned `StorageAdapter` contract and exportable StrataGate snapshots
- add a transactional SQLite adapter with normalized tables, WAL, foreign keys, schema versioning, and per-namespace optimistic concurrency
- persist open-tail messages before external model calls and track extraction jobs for restart-safe recovery
- add idempotent adoption receipts and rollback stale in-memory writers on revision conflicts
- expose SQLite through `@diqier/stratagate/sqlite` with `better-sqlite3` as an optional peer dependency
- update the English and Chinese documentation and examples

## Why

The in-memory reference store lost recent raw messages, block state, event provenance, extraction progress, and adoption weights whenever a process restarted. This adds a durable backend without changing the existing retrieval ranking semantics.

## User and developer impact

Persistent instances are opened with `await StrataGate.open(...)`. Methods that persist state, including `searchEvents()`, `recordMemoryUse()`, `expandBlock()`, and governance mutations, are now asynchronous. Persistent adoption calls require a stable `receiptId` so framework retries do not strengthen the same memory twice. The minimum supported Node.js version is now 22.

SQLite storage does not encrypt the database file and does not yet provide database-native full-text or vector search.

## Validation

- `npm run check`
- `npm test` - 11 tests passed, including 6 SQLite persistence and recovery tests
- `npm run build`
- built SQLite entrypoint smoke test
- `npm pack --dry-run --json`
- `git diff --check`
