### PR TITLE
Add element projection and BM25/RRF hybrid retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This is a single-conversation comparison on `conv-26`, not a full LoCoMo score. 
 
 ![StrataGate workflow: layered memory, event cards, and the evidence gate](docs/assets/stratagate-how-it-works.en.png)
 
-Conversations are sealed into layered memories at different levels of detail, and event cards with provenance and time are extracted from them. When a question arrives, the system retrieves evidence and assesses whether it is sufficient. If not, it continues by expanding events or returning to the original messages; it answers only after the evidence is sufficient.
+Conversations are sealed into layered memories at different levels of detail, and immutable event cards with provenance and time are extracted from them. Separately retryable element projection turns those events into current views of people, projects, organizations, tools, and places. When a question arrives, BM25 and structured rankings are fused with RRF across event and fact-level element search. The system then assesses whether the evidence is sufficient; if not, it expands a card or returns to the original messages.
 
 ## Core design
 
@@ -133,7 +133,15 @@ Event extraction is delayed: after block `N` is sealed, precise extraction waits
 
 This reduces the chance that context is cut at a block boundary while preventing facts from neighboring conversations from being written into the wrong event.
 
-### 3. Evidence gate: relevant does not mean sufficient
+### 3. Element cards and auditable hybrid retrieval
+
+Event cards preserve what happened. Element cards materialize what is currently true about a person, project, organization, tool, or place. Their facts have `state`, `set`, or `relation` semantics, valid intervals, and source event IDs.
+
+Element projection is an independent persisted job. A failed projection can be retried without extracting its events again. The projector may propose changes, but StrataGate applies a fact only when every cited event belongs to the claimed projection batch. Updating a state supersedes the old fact and closes its validity interval; it never rewrites the source event.
+
+`searchEvents()` and `searchElements()` use deterministic BM25 lexical ranking plus structured rankings such as participant, event type, element name, element type, and time. Reciprocal-rank fusion combines those lists. Element search returns fact-level hits instead of an entire potentially large card, and a lexical zero match returns no arbitrary candidates. This evaluated path does not use vector or semantic retrieval.
+
+### 4. Evidence gate: relevant does not mean sufficient
 
 A conventional retrieval system often hands several similar results directly to the answer model. StrataGate inserts a fixed protocol between retrieval and answering:
 
@@ -160,23 +168,25 @@ If the judgment is `partial` or `wrong`, the system can choose:
 ```text
 search_events
 expand_event
+search_elements
+expand_element
 search_raw_memory
 expand_block
 ```
 
 The evidence gate does not run the entire agent loop for the application. StrataGate supplies state, constraints, and validation; the integrating application still controls model calls, tool iteration, and the maximum retrieval budget.
 
-### 4. Separate retrieval from reinforcement
+### 5. Separate retrieval from reinforcement
 
 An event being retrieved does not mean that it helped the answer.
 
 Search therefore updates only observable retrieval records; it does not directly increase memory weight. After the answer is complete, the application explicitly calls:
 
 ```ts
-await memory.recordMemoryUse(eventIds);
+await memory.recordMemoryUse({ eventIds, elementIds });
 ```
 
-Only events that the answer actually used update their long-term weight.
+Only events and elements that the answer actually used update their long-term weight.
 
 This avoids a common feedback loop:
 
@@ -277,6 +287,8 @@ The repository has implemented and validated:
 
 - layered conversation blocks and their decay rules;
 - event cards with provenance, time, and conflict relationships;
+- independently retryable element-card projection with event-level provenance and historical state;
+- BM25/RRF event and fact-level element retrieval with structured rankings;
 - a bounded evidence gate whose constraints can be checked by code;
 - a weighting mechanism that separates retrieval hits from actual answer use;
 - automated tests, experiment records, and machine-readable evaluation results.
@@ -301,7 +313,9 @@ npm run build
 The main code and documentation entry points are:
 
 - [`examples/basic.ts`](examples/basic.ts): minimal code example;
-- [`src/store.ts`](src/store.ts): core state, lifecycle, and event retrieval;
+- [`src/store.ts`](src/store.ts): core state, event/element lifecycle, and retrieval;
+- [`src/elements.ts`](src/elements.ts): provenance-checked element projection and time views;
+- [`src/search.ts`](src/search.ts): deterministic BM25 token ranking and RRF fusion;
 - [`src/retrieval.ts`](src/retrieval.ts): evidence-gate normalization and constraint validation;
 - [`src/blocks.ts`](src/blocks.ts): layering rules and deterministic pruning;
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md): complete system boundaries and implementation invariants;
@@ -313,7 +327,7 @@ The main code and documentation entry points are:
 
 | Resource | Contents |
 | --- | --- |
-| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Data flow, layering rules, event-card protocol, evidence-gate constraints, weighting, and storage invariants |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Data flow, layering rules, event/element protocols, hybrid retrieval, evidence-gate constraints, weighting, and storage invariants |
 | [`docs/EVALUATION.md`](docs/EVALUATION.md) | R1–R8 experiments, model sensitivity, Mem0 comparison, failure analysis, and reporting boundaries |
 | [`benchmarks/locomo-conv26-r8-final.json`](benchmarks/locomo-conv26-r8-final.json) | Current result, per-stage statistics, run information, and source artifact hashes |
 | [`examples/basic.ts`](examples/basic.ts) | Minimal code example |
@@ -323,10 +337,12 @@ The main code and documentation entry points are:
 ```text
 src/
   blocks.ts       Conversation layering, deterministic pruning, and level decay
+  elements.ts     Provenance-checked element projection and temporal views
   retrieval.ts    Evidence-gate input, normalization, and constraint validation
+  search.ts       BM25 lexical ranking and reciprocal-rank fusion
   storage.ts      Persistent snapshots and the StorageAdapter protocol
   sqlite.ts       Optional transactional SQLite adapter
-  store.ts        In-memory state, event retrieval, and lifecycle
+  store.ts        In-memory state, event/element retrieval, and lifecycle
   types.ts        Data structures and model-adapter interfaces
   weights.ts      Adoption records, forgetting, and weighting rules
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,7 +68,7 @@ StrataGate 的目标不是让 Agent 每次检索更多，而是让它知道：**
 
 ![StrataGate 工作流程：分层记忆、事件卡与证据门](docs/assets/stratagate-how-it-works.zh-CN.png)
 
-对话被封存为不同详细程度的分层记忆，并从中抽取带来源和时间的事件卡。问题到来后，系统先检索并判断证据是否充分；不足时继续展开事件或回查原始消息，证据充分后才回答。
+对话被封存为不同详细程度的分层记忆，并从中抽取带来源和时间、不可改写的事件卡。随后，独立且可重试的元素投影会根据事件生成“人物、项目、组织、工具、地点”的当前视图。问题到来后，事件检索与元素事实检索分别使用 BM25 和结构化排序，再通过 RRF 融合；系统继续判断证据是否充分，不足时展开卡片或回查原始消息。
 
 ## 核心设计
 
@@ -133,7 +133,15 @@ L0–L4 都是同一份来源的派生视图，不会覆盖或重写 L5。事件
 
 这样既能减少上下文被块边界切断的问题，又能阻止相邻对话中的事实被错误写入当前事件。
 
-### 3. 证据门：相关不等于充分
+### 3. 元素卡与可审计的混合检索
+
+事件卡保存“发生过什么”，元素卡投影“某个人、项目、组织、工具或地点当前是什么状态”。元素事实分为 `state`、`set`、`relation` 三类，同时保存有效时间范围和来源事件 ID。
+
+元素投影是独立的持久化任务。投影失败时，只重试这次投影，不会重新抽取已经成功写入的事件。投影器可以提出变更，但只有当一条事实引用的所有事件都属于当前投影批次时，StrataGate 才会落库。状态更新会把旧事实标记为已取代并关闭有效期，不会修改来源事件。
+
+`searchEvents()` 和 `searchElements()` 使用确定性的 BM25 词面排序，并结合参与者、事件类型、元素名称、元素类型和时间等结构化排序，再用 RRF 融合。元素检索按事实返回，不会直接塞回一整张可能很大的元素卡；真正零词面命中时也不会把全部候选当作结果返回。这条已评测路径不使用向量或语义检索。
+
+### 4. 证据门：相关不等于充分
 
 普通检索系统通常在返回若干相似结果后，直接把它们交给回答模型。StrataGate 在检索和回答之间增加了一层固定协议：
 
@@ -160,23 +168,25 @@ verdict · evidence_refs · fit · missing · next_strategy
 ```text
 search_events
 expand_event
+search_elements
+expand_element
 search_raw_memory
 expand_block
 ```
 
 证据门不负责替应用完成整个 Agent loop。StrataGate 提供状态、约束和校验，具体模型调用、工具循环和最大检索预算仍由接入方控制。
 
-### 4. 检索和强化分开
+### 5. 检索和强化分开
 
 一次事件被搜索到，不代表它真的帮助了答案。
 
 因此，搜索只更新可观测的检索记录，不会直接增加记忆权重。回答完成后，应用需要显式调用：
 
 ```ts
-await memory.recordMemoryUse(eventIds);
+await memory.recordMemoryUse({ eventIds, elementIds });
 ```
 
-只有真正被答案采用的事件才会更新长期权重。
+只有真正被答案采用的事件和元素才会更新长期权重。
 
 这样可以避免一个常见反馈循环：
 
@@ -277,6 +287,8 @@ StrataGate 目前是用于验证长期 Agent 记忆设计的研究型原型。
 
 - 分层对话块及其衰减规则；
 - 带来源、时间和冲突关系的事件卡；
+- 独立可重试、保留事件来源和历史状态的元素卡投影；
+- BM25/RRF 事件检索与元素事实级混合检索；
 - 长度有界、可由代码校验的证据门；
 - 检索命中与实际采用分离的权重机制；
 - 自动化测试、实验记录和机器可读评测结果。
@@ -301,7 +313,9 @@ npm run build
 代码与文档的主要入口：
 
 - [`examples/basic.ts`](examples/basic.ts)：最小代码示例；
-- [`src/store.ts`](src/store.ts)：核心状态、生命周期和事件检索；
+- [`src/store.ts`](src/store.ts)：核心状态、事件/元素生命周期和检索；
+- [`src/elements.ts`](src/elements.ts)：校验来源的元素投影与时间视图；
+- [`src/search.ts`](src/search.ts)：确定性 BM25 排序和 RRF 融合；
 - [`src/retrieval.ts`](src/retrieval.ts)：证据门规范化与约束校验；
 - [`src/blocks.ts`](src/blocks.ts)：分层规则与确定性精简；
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)：完整系统边界与实现不变量；
@@ -313,7 +327,7 @@ npm run build
 
 | 资源 | 内容 |
 | --- | --- |
-| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | 数据流、分层规则、事件卡协议、证据门约束、权重和存储不变量 |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | 数据流、分层规则、事件/元素协议、混合检索、证据门约束、权重和存储不变量 |
 | [`docs/EVALUATION.md`](docs/EVALUATION.md) | R1–R8 实验、模型敏感性、Mem0 对比、失败分析和报告边界 |
 | [`benchmarks/locomo-conv26-r8-final.json`](benchmarks/locomo-conv26-r8-final.json) | 当前结果、逐阶段统计、运行信息和源产物哈希 |
 | [`examples/basic.ts`](examples/basic.ts) | 最小代码示例 |
@@ -323,10 +337,12 @@ npm run build
 ```text
 src/
   blocks.ts       对话块分层、确定性精简和层级衰减
+  elements.ts     校验来源的元素投影和时间视图
   retrieval.ts    证据门输入、规范化和约束校验
+  search.ts       BM25 词面排序和 RRF 融合
   storage.ts      持久化快照和 StorageAdapter 协议
   sqlite.ts       可选的事务式 SQLite adapter
-  store.ts        内存状态、事件检索和生命周期
+  store.ts        内存状态、事件/元素检索和生命周期
   types.ts        数据结构和模型适配接口
   weights.ts      采用记录、遗忘和权重规则
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,8 +15,12 @@ flowchart TB
 
     subgraph Derived["Derived memory"]
       E["Temporal event cards"]
+      P["Retryable element projection"]
+      C["Current element cards"]
       W["Adoption-based weight state"]
+      E --> P --> C
       E --> W
+      C --> W
     end
 
     subgraph Retrieval["Retrieval control"]
@@ -31,11 +35,12 @@ flowchart TB
     B --> E
     L --> Retrieval
     E --> Retrieval
+    C --> Retrieval
     A -->|"sufficient"| U["Answer and usage receipt"]
     U --> W
 ```
 
-The data flow from blocks to event cards is one-way. Derived cards never rewrite their source block.
+The data flow from blocks to event cards and from events to element cards is one-way. Derived cards never rewrite their source block or source event.
 
 ## Conversation blocks
 
@@ -118,6 +123,29 @@ interface EventCard {
 
 `mentionedAt` answers when the conversation referred to the event. `happenedStart` and `happenedEnd` answer when the event itself occurred. Keeping these axes separate avoids treating the message timestamp as the event date.
 
+## Element-card projection
+
+Event cards are immutable history. Element cards are rebuildable materialized views across events for people, projects, organizations, tools, and places. Each element fact has one of three modes:
+
+- `state`: a new fact with the same key supersedes the previous active state;
+- `set`: new unique values are appended without replacing existing values;
+- `relation`: a new relation with the same key supersedes the previous active relation.
+
+Facts carry `validFrom`, optional `validTo`, confidence, and `sourceEventIds`. Replacing a state closes the previous fact's validity interval instead of deleting it. `expandElement(id, at)` can therefore reconstruct the view at an earlier time.
+
+Projection is a separate persisted job from event extraction. The runtime commits a `pending` job only after its events exist. It then claims the job, calls the application-provided projector outside the transaction, and atomically applies the result or records failure. Every proposed fact is ignored unless all of its source event IDs belong to the claimed batch. An interrupted `running` job becomes `failed` on restart and can be retried without re-extracting events.
+
+Applications that manage their own model loop may use `claimNextElementProjection()`, `completeElementProjection()`, and `failElementProjection()` directly. Supplying `elementProjector` lets `appendTurn()` and `resumePendingWork()` drive the same state machine automatically.
+
+## Hybrid retrieval
+
+Event and fact-level element search use two inspectable ranking sources:
+
+1. BM25 over field-weighted lexical tokens, including overlapping Han bigrams;
+2. structured rankings from fields such as participant, event type, time range, element name, and element type.
+
+Reciprocal-rank fusion combines the available rankings. A non-empty query with no lexical or structured match returns an empty result rather than all candidates. Element search returns the matched fact plus its element ID, validity interval, and event provenance; callers expand the full element card only when needed. The reference path does not use embeddings or vector similarity.
+
 ## Event weight and adoption
 
 Event decay uses:
@@ -154,6 +182,8 @@ interface RetrievalAssessment {
     | 'answer'
     | 'search_events'
     | 'expand_event'
+    | 'search_elements'
+    | 'expand_element'
     | 'search_raw_memory'
     | 'expand_block';
 }
@@ -169,7 +199,7 @@ If the retrieval budget ends without sufficient evidence, the caller should pass
 
 ## Storage adapters
 
-The default constructor is an in-memory reference store. `StrataGate.open()` can instead hydrate the same state machine from a `StorageAdapter`. The bundled `SqliteStorage` adapter persists normalized rows for memory spaces, messages, blocks, events, event sources, extraction jobs, and usage receipts.
+The default constructor is an in-memory reference store. `StrataGate.open()` can instead hydrate the same state machine from a `StorageAdapter`. The bundled `SqliteStorage` adapter persists normalized rows for memory spaces, messages, blocks, events, elements, facts, provenance links, extraction/projection jobs, and usage receipts.
 
 Every namespace has a monotonically increasing revision. A write supplies the revision it loaded; SQLite commits the new revision and all related rows in one immediate transaction. A stale process receives `StorageConflictError` rather than overwriting newer state.
 
@@ -178,7 +208,8 @@ External model calls are never made inside a database transaction:
 1. a completed raw turn is committed immediately;
 2. summarization runs outside the transaction, then sealing commits atomically;
 3. extraction first commits a running job, calls the extractor, then atomically commits either the event cards or a failed/skipped job state;
-4. `resumePendingWork()` retries only failed or interrupted work after restart.
+4. element projection follows the same claim/call/complete boundary after its source events are durable;
+5. `resumePendingWork()` retries only failed or interrupted work after restart.
 
 The adapter preserves these invariants:
 
@@ -186,7 +217,9 @@ The adapter preserves these invariants:
 - card provenance references an existing source block and message set;
 - search hits do not increment adoption state;
 - supersession retains the old event;
+- element state replacement retains the old fact and its validity interval;
+- every element and fact source references an existing immutable event;
 - forget is reversible unless an application explicitly implements irreversible deletion;
 - usage receipts are idempotent for one answer turn through a unique `receiptId`.
 
-SQLite uses WAL, foreign keys, and per-namespace optimistic concurrency. It does not provide encryption at rest. Search still uses the reference in-memory ranking after hydration, so enabling persistence does not silently change retrieval semantics. Database-native lexical/vector indexes and a Postgres implementation remain separate future work.
+SQLite schema v2 adds normalized element, fact, provenance, and projection-job tables. Opening a schema-v1 database migrates it in one transaction and preserves existing namespaces, blocks, events, jobs, and receipts. SQLite uses WAL, foreign keys, and per-namespace optimistic concurrency. It does not provide encryption at rest. Search still uses the reference in-memory ranking after hydration, so enabling persistence does not silently change retrieval semantics. Database-native lexical/vector indexes and a Postgres implementation remain separate future work.

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,4 +1,9 @@
-import { StrataGate, type BlockSummarizer, type EventExtractor } from '../src/index.js';
+import {
+  StrataGate,
+  type BlockSummarizer,
+  type ElementProjector,
+  type EventExtractor,
+} from '../src/index.js';
 
 const summarize: BlockSummarizer = async (messages) => ({
   l0Title: 'API design discussion',
@@ -21,7 +26,27 @@ const extract: EventExtractor = async ({ target }) => ({
   }],
 });
 
-const memory = new StrataGate({ blockTurnSize: 1, summarizer: summarize, extractor: extract });
+// Element cards are a separately retryable materialized view. The callback may
+// call any model provider; StrataGate validates every proposed source event ID.
+const projectElements: ElementProjector = async ({ events }) => ({
+  reason: 'Update the current project view from the new immutable event.',
+  changes: events.map((event) => ({
+    element: { name: 'Public API', type: 'project' },
+    operation: 'set_state',
+    key: 'pagination',
+    mode: 'state',
+    value: 'cursor pagination',
+    sourceEventIds: [event.id],
+    confidence: 1,
+  })),
+});
+
+const memory = new StrataGate({
+  blockTurnSize: 1,
+  summarizer: summarize,
+  extractor: extract,
+  elementProjector: projectElements,
+});
 
 await memory.appendTurn({
   user: 'Let us use cursor pagination for the public API.',
@@ -36,7 +61,11 @@ await memory.appendTurn({
 });
 
 const results = await memory.searchEvents('How should the API paginate?');
-const evidence = new Set(results.map(({ event }) => event.id));
+const elementFacts = await memory.searchElements('current API pagination', { type: 'project' });
+const evidence = new Set([
+  ...results.map(({ event }) => event.id),
+  ...elementFacts.map(({ id }) => id),
+]);
 const assessment = memory.assessRetrieval({
   verdict: 'sufficient',
   evidence_refs: [...evidence],
@@ -46,6 +75,9 @@ const assessment = memory.assessRetrieval({
 }, evidence);
 
 if (assessment.verdict === 'sufficient') {
-  await memory.recordMemoryUse(assessment.evidenceRefs);
-  console.log(results[0]?.event.summary);
+  await memory.recordMemoryUse({
+    eventIds: results.map(({ event }) => event.id),
+    elementIds: [...new Set(elementFacts.map(({ elementId }) => elementId))],
+  });
+  console.log(elementFacts[0]?.fact.value ?? results[0]?.event.summary);
 }

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -1,0 +1,182 @@
+import { normalizeSearchText } from './search.js';
+import type {
+  ElementCard,
+  ElementFact,
+  ElementFactMode,
+  ElementProjectionChange,
+  EventCard,
+  MemoryElementType,
+} from './types.js';
+import { criticalityFloor } from './weights.js';
+
+const ELEMENT_TYPES = new Set<MemoryElementType>(['person', 'project', 'organization', 'tool', 'place']);
+const FACT_MODES = new Set<ElementFactMode>(['state', 'set', 'relation']);
+
+function compactText(value: unknown, limit: number): string {
+  return typeof value === 'string' ? value.trim().replace(/\s+/g, ' ').slice(0, limit) : '';
+}
+
+function stringList(value: unknown, limit: number, itemLimit = 240): string[] {
+  return Array.isArray(value)
+    ? [...new Set(value.map((item) => compactText(item, itemLimit)).filter(Boolean))].slice(0, limit)
+    : [];
+}
+
+function eventChronology(event: EventCard): string {
+  return event.temporal.happenedStart
+    ?? event.temporal.happenedEnd
+    ?? event.temporal.mentionedAt
+    ?? event.createdAt;
+}
+
+export function renderElementState(facts: readonly ElementFact[], includeHistorical = false): string {
+  const visible = includeHistorical ? facts : facts.filter((fact) => fact.status === 'active');
+  const sets = new Map<string, string[]>();
+  const lines: string[] = [];
+  for (const fact of visible) {
+    const values = Array.isArray(fact.value) ? fact.value : [fact.value];
+    if (fact.mode === 'set') {
+      sets.set(fact.key, [...new Set([...(sets.get(fact.key) ?? []), ...values])]);
+    } else {
+      lines.push(`${fact.key}: ${values.join(', ')}`);
+    }
+  }
+  for (const [key, values] of sets) lines.push(`${key}: ${values.join(', ')}`);
+  return lines.join('\n');
+}
+
+export interface ApplyElementChangesOptions {
+  elements: ElementCard[];
+  events: readonly EventCard[];
+  changes: readonly ElementProjectionChange[];
+  allowedEventIds: ReadonlySet<string>;
+  now: string;
+  currentTurn: number;
+  idFactory: (prefix: 'elem' | 'fact') => string;
+}
+
+/**
+ * Applies a model-proposed materialized view only when every fact cites an
+ * event from the claimed projection batch. Events themselves are never edited.
+ */
+export function applyElementChanges(options: ApplyElementChangesOptions): ElementCard[] {
+  const touched = new Map<string, ElementCard>();
+  for (const rawChange of options.changes) {
+    const name = compactText(rawChange.element?.name, 160);
+    const type = rawChange.element?.type;
+    const key = compactText(rawChange.key, 160);
+    const mode = rawChange.mode;
+    const operation = rawChange.operation;
+    const requestedSourceEventIds = stringList(rawChange.sourceEventIds, 24);
+    const sourceEventIds = requestedSourceEventIds.filter((id) => options.allowedEventIds.has(id));
+    const rawValue = rawChange.value;
+    const value = Array.isArray(rawValue) ? stringList(rawValue, 40) : compactText(rawValue, 1_200);
+    const operationMatchesMode = (mode === 'state' && operation === 'set_state')
+      || (mode === 'set' && operation === 'add_set_item')
+      || (mode === 'relation' && operation === 'set_relation');
+    if (!name || !ELEMENT_TYPES.has(type) || !key || !FACT_MODES.has(mode)
+      || !operationMatchesMode || sourceEventIds.length === 0
+      || sourceEventIds.length !== requestedSourceEventIds.length
+      || (Array.isArray(value) ? value.length === 0 : !value)) continue;
+
+    const aliases = stringList(rawChange.element?.aliases, 20, 160)
+      .filter((alias) => normalizeSearchText(alias) !== normalizeSearchText(name));
+    const knownNames = new Set([name, ...aliases].map(normalizeSearchText));
+    let element = options.elements.find((candidate) => candidate.type === type
+      && [candidate.name, ...candidate.aliases]
+        .some((candidateName) => knownNames.has(normalizeSearchText(candidateName))));
+    if (!element) {
+      element = {
+        id: options.idFactory('elem'),
+        name,
+        type,
+        aliases,
+        currentState: '',
+        facts: [],
+        sourceEventIds: [],
+        sourceMessageIds: [],
+        weight: {
+          mentionCount: 1,
+          lastAdoptedTurn: options.currentTurn,
+          lastRetrievedAt: null,
+          pinned: false,
+          floorWeight: criticalityFloor('routine'),
+          forcedCap: null,
+        },
+        createdAt: options.now,
+        updatedAt: options.now,
+      };
+      options.elements.push(element);
+    } else {
+      element.aliases = [...new Set([...element.aliases, ...aliases])];
+    }
+
+    const sourceEvents = sourceEventIds.flatMap((id) => options.events.find((event) => event.id === id) ?? []);
+    const validFrom = compactText(rawChange.validFrom, 80)
+      || sourceEvents.map(eventChronology).sort().at(-1)
+      || options.now;
+    const validTo = compactText(rawChange.validTo, 80) || undefined;
+    if (mode !== 'set') {
+      for (const fact of element.facts.filter((candidate) =>
+        candidate.status === 'active' && candidate.key === key && candidate.mode === mode)) {
+        fact.status = 'superseded';
+        if (!fact.validTo) fact.validTo = validFrom;
+        fact.updatedAt = options.now;
+      }
+    }
+
+    const existingSetValues = new Set(element.facts
+      .filter((fact) => fact.status === 'active' && fact.mode === 'set' && fact.key === key)
+      .flatMap((fact) => Array.isArray(fact.value) ? fact.value : [fact.value])
+      .map(normalizeSearchText));
+    const factValue = mode === 'set'
+      ? (Array.isArray(value) ? value : [value])
+        .filter((item) => !existingSetValues.has(normalizeSearchText(item)))
+      : value;
+    if (mode !== 'set' || factValue.length > 0) {
+      const fact: ElementFact = {
+        id: options.idFactory('fact'),
+        key,
+        mode,
+        value: factValue,
+        ...(validFrom ? { validFrom } : {}),
+        ...(validTo ? { validTo } : {}),
+        sourceEventIds,
+        ...(typeof rawChange.confidence === 'number'
+          ? { confidence: Math.max(0, Math.min(1, rawChange.confidence)) }
+          : {}),
+        status: 'active',
+        createdAt: options.now,
+        updatedAt: options.now,
+      };
+      element.facts.push(fact);
+    }
+    element.sourceEventIds = [...new Set([...element.sourceEventIds, ...sourceEventIds])];
+    element.sourceMessageIds = [...new Set([
+      ...element.sourceMessageIds,
+      ...sourceEvents.flatMap((event) => event.sourceMessageIds),
+    ])];
+    element.currentState = renderElementState(element.facts);
+    element.updatedAt = options.now;
+    touched.set(element.id, element);
+  }
+  return [...touched.values()];
+}
+
+function dateValue(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function elementViewAt(element: ElementCard, at?: string): ElementCard {
+  const view = structuredClone(element);
+  if (!at) return view;
+  const instant = dateValue(at, Number.NaN);
+  if (!Number.isFinite(instant)) return view;
+  view.facts = view.facts.filter((fact) =>
+    dateValue(fact.validFrom, Number.NEGATIVE_INFINITY) <= instant
+    && dateValue(fact.validTo, Number.POSITIVE_INFINITY) >= instant);
+  view.currentState = renderElementState(view.facts, true);
+  return view;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './blocks.js';
 export * from './retrieval.js';
+export * from './search.js';
 export * from './storage.js';
 export * from './store.js';
 export * from './types.js';

--- a/src/retrieval.ts
+++ b/src/retrieval.ts
@@ -1,9 +1,11 @@
-export const RETRIEVAL_CONTRACT_VERSION = 4;
+export const RETRIEVAL_CONTRACT_VERSION = 5;
 
 export const RETRIEVAL_STRATEGIES = [
   'answer',
   'search_events',
   'expand_event',
+  'search_elements',
+  'expand_element',
   'search_raw_memory',
   'expand_block',
 ] as const;

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,106 @@
+const wordSegmenter = new Intl.Segmenter(undefined, { granularity: 'word' });
+
+export function normalizeSearchText(value: string): string {
+  return value.normalize('NFKC').toLocaleLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Word segmentation handles whitespace-delimited languages while overlapping
+ * Han bigrams preserve recall for names and domain terms with unstable
+ * segmentation. The output is deterministic and does not require embeddings.
+ */
+export function searchTokens(value: string): string[] {
+  const normalized = normalizeSearchText(value);
+  if (!normalized) return [];
+  const tokens: string[] = [];
+  for (const part of wordSegmenter.segment(normalized)) {
+    const segment = part.segment.trim();
+    if (part.isWordLike && segment) tokens.push(`word:${segment}`);
+  }
+  for (const match of normalized.matchAll(/\p{Script=Han}+/gu)) {
+    const characters = [...match[0]];
+    if (characters.length === 1) tokens.push(`han1:${characters[0]}`);
+    for (let index = 0; index < characters.length - 1; index += 1) {
+      tokens.push(`han2:${characters[index]}${characters[index + 1]}`);
+    }
+  }
+  return tokens;
+}
+
+export function fuzzySearchMatch(candidate: string, requested: string): boolean {
+  const left = normalizeSearchText(candidate);
+  const right = normalizeSearchText(requested);
+  return Boolean(left && right && (left === right || left.includes(right) || right.includes(left)));
+}
+
+export function weightedSearchTokens(fields: ReadonlyArray<readonly [string, number]>): string[] {
+  return fields.flatMap(([value, rawWeight]) => {
+    const tokens = searchTokens(value);
+    const weight = Math.max(1, Math.floor(rawWeight));
+    return Array.from({ length: weight }, () => tokens).flat();
+  });
+}
+
+export interface RankedItem<T> {
+  item: T;
+  score: number;
+}
+
+/** BM25 ranks only documents with a real query-term match. */
+export function bm25Rank<T extends { id: string }>(
+  items: readonly T[],
+  query: string,
+  document: (item: T) => string[],
+): Array<RankedItem<T>> {
+  const terms = [...new Set(searchTokens(query))];
+  if (terms.length === 0 || items.length === 0) return [];
+  const documents = items.map((item) => document(item));
+  const averageLength = documents.reduce((total, tokens) => total + tokens.length, 0) / documents.length || 1;
+  const documentFrequency = new Map<string, number>();
+  for (const tokens of documents) {
+    for (const token of new Set(tokens)) {
+      documentFrequency.set(token, (documentFrequency.get(token) ?? 0) + 1);
+    }
+  }
+
+  const k1 = 1.2;
+  const b = 0.75;
+  return items.map((item, index) => {
+    const tokens = documents[index] ?? [];
+    const frequencies = new Map<string, number>();
+    for (const token of tokens) frequencies.set(token, (frequencies.get(token) ?? 0) + 1);
+    let score = 0;
+    for (const term of terms) {
+      const frequency = frequencies.get(term) ?? 0;
+      if (frequency === 0) continue;
+      const frequencyInDocuments = documentFrequency.get(term) ?? 0;
+      const inverseDocumentFrequency = Math.log(
+        1 + (items.length - frequencyInDocuments + 0.5) / (frequencyInDocuments + 0.5),
+      );
+      score += inverseDocumentFrequency * (
+        (frequency * (k1 + 1))
+        / (frequency + k1 * (1 - b + b * tokens.length / averageLength))
+      );
+    }
+    return { item, score };
+  }).filter(({ score }) => score > 0)
+    .sort((left, right) => right.score - left.score || left.item.id.localeCompare(right.item.id));
+}
+
+/** Reciprocal-rank fusion combines independently auditable rankings. */
+export function rrfRank<T extends { id: string }>(rankings: ReadonlyArray<readonly T[]>): Array<RankedItem<T>> {
+  const fused = new Map<string, { item: T; score: number; bestRank: number }>();
+  for (const ranking of rankings) {
+    ranking.forEach((item, index) => {
+      const current = fused.get(item.id) ?? { item, score: 0, bestRank: Number.POSITIVE_INFINITY };
+      current.score += 1 / (60 + index + 1);
+      current.bestRank = Math.min(current.bestRank, index);
+      fused.set(item.id, current);
+    });
+  }
+  return [...fused.values()]
+    .sort((left, right) => right.score - left.score
+      || left.bestRank - right.bestRank
+      || left.item.id.localeCompare(right.item.id))
+    .map(({ item, score }) => ({ item, score }));
+}

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -4,6 +4,7 @@ import {
   StorageConflictError,
   assertValidSnapshot,
   cloneSnapshot,
+  type ElementProjectionJob,
   type ExtractionJob,
   type LoadedStrataGateState,
   type StorageAdapter,
@@ -12,12 +13,17 @@ import {
 } from './storage.js';
 import type {
   BlockLevel,
+  ElementCard,
+  ElementFact,
+  ElementFactMode,
+  ElementFactStatus,
   EventCard,
   EventTemporal,
   MemoryBlock,
   MemoryCriticality,
   MemoryScope,
   MemoryStatus,
+  MemoryElementType,
   RawMessage,
   ToolTrace,
 } from './types.js';
@@ -106,7 +112,64 @@ interface ExtractionJobRow {
 interface UsageReceiptRow {
   receipt_id: string;
   event_ids_json: string;
+  element_ids_json: string;
   created_at: string;
+}
+
+interface ElementRow {
+  id: string;
+  position: number;
+  name: string;
+  type: MemoryElementType;
+  aliases_json: string;
+  current_state: string;
+  mention_count: number;
+  last_adopted_turn: number;
+  last_retrieved_at: string | null;
+  pinned: number;
+  floor_weight: number;
+  forced_cap: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ElementFactRow {
+  id: string;
+  element_id: string;
+  position: number;
+  key: string;
+  mode: ElementFactMode;
+  value_json: string;
+  valid_from: string | null;
+  valid_to: string | null;
+  confidence: number | null;
+  status: ElementFactStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ElementSourceRow {
+  element_id: string;
+  event_id: string;
+  position: number;
+}
+
+interface ElementFactSourceRow {
+  fact_id: string;
+  event_id: string;
+  position: number;
+}
+
+interface ElementProjectionJobRow {
+  id: string;
+  source_event_ids_json: string;
+  status: ElementProjectionJob['status'];
+  attempts: number;
+  element_ids_json: string;
+  reason: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 const SCHEMA = `
@@ -197,6 +260,64 @@ CREATE TABLE IF NOT EXISTS event_sources (
   FOREIGN KEY (namespace, message_id) REFERENCES messages(namespace, id)
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS elements (
+  namespace TEXT NOT NULL,
+  id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  aliases_json TEXT NOT NULL,
+  current_state TEXT NOT NULL,
+  mention_count INTEGER NOT NULL,
+  last_adopted_turn INTEGER NOT NULL,
+  last_retrieved_at TEXT,
+  pinned INTEGER NOT NULL,
+  floor_weight REAL NOT NULL,
+  forced_cap REAL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (namespace, id),
+  FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS element_sources (
+  namespace TEXT NOT NULL,
+  element_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  PRIMARY KEY (namespace, element_id, event_id),
+  FOREIGN KEY (namespace, element_id) REFERENCES elements(namespace, id) ON DELETE CASCADE,
+  FOREIGN KEY (namespace, event_id) REFERENCES events(namespace, id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS element_facts (
+  namespace TEXT NOT NULL,
+  id TEXT NOT NULL,
+  element_id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  key TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  value_json TEXT NOT NULL,
+  valid_from TEXT,
+  valid_to TEXT,
+  confidence REAL,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (namespace, id),
+  FOREIGN KEY (namespace, element_id) REFERENCES elements(namespace, id) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS element_fact_sources (
+  namespace TEXT NOT NULL,
+  fact_id TEXT NOT NULL,
+  event_id TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  PRIMARY KEY (namespace, fact_id, event_id),
+  FOREIGN KEY (namespace, fact_id) REFERENCES element_facts(namespace, id) ON DELETE CASCADE,
+  FOREIGN KEY (namespace, event_id) REFERENCES events(namespace, id)
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS extraction_jobs (
   namespace TEXT NOT NULL,
   block_id TEXT NOT NULL,
@@ -208,10 +329,26 @@ CREATE TABLE IF NOT EXISTS extraction_jobs (
   FOREIGN KEY (namespace, block_id) REFERENCES blocks(namespace, id) ON DELETE CASCADE
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS element_projection_jobs (
+  namespace TEXT NOT NULL,
+  id TEXT NOT NULL,
+  source_event_ids_json TEXT NOT NULL,
+  status TEXT NOT NULL,
+  attempts INTEGER NOT NULL,
+  element_ids_json TEXT NOT NULL,
+  reason TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (namespace, id),
+  FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS usage_receipts (
   namespace TEXT NOT NULL,
   receipt_id TEXT NOT NULL,
   event_ids_json TEXT NOT NULL,
+  element_ids_json TEXT NOT NULL,
   created_at TEXT NOT NULL,
   PRIMARY KEY (namespace, receipt_id),
   FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE
@@ -355,6 +492,78 @@ export class SqliteStorage implements StorageAdapter {
       updatedAt: row.updated_at,
     }));
 
+    const elementSourceRows = this.database.prepare(`
+      SELECT element_id, event_id, position FROM element_sources
+      WHERE namespace = ? ORDER BY element_id, position
+    `).all(key) as ElementSourceRow[];
+    const sourcesByElement = new Map<string, string[]>();
+    for (const row of elementSourceRows) {
+      const ids = sourcesByElement.get(row.element_id) ?? [];
+      ids.push(row.event_id);
+      sourcesByElement.set(row.element_id, ids);
+    }
+
+    const elementFactSourceRows = this.database.prepare(`
+      SELECT fact_id, event_id, position FROM element_fact_sources
+      WHERE namespace = ? ORDER BY fact_id, position
+    `).all(key) as ElementFactSourceRow[];
+    const sourcesByFact = new Map<string, string[]>();
+    for (const row of elementFactSourceRows) {
+      const ids = sourcesByFact.get(row.fact_id) ?? [];
+      ids.push(row.event_id);
+      sourcesByFact.set(row.fact_id, ids);
+    }
+
+    const elementFactRows = this.database.prepare(`
+      SELECT * FROM element_facts WHERE namespace = ? ORDER BY element_id, position
+    `).all(key) as ElementFactRow[];
+    const factsByElement = new Map<string, ElementFact[]>();
+    for (const row of elementFactRows) {
+      const facts = factsByElement.get(row.element_id) ?? [];
+      facts.push({
+        id: row.id,
+        key: row.key,
+        mode: row.mode,
+        value: parseJson<string | string[]>(row.value_json, 'element_facts.value_json'),
+        ...(row.valid_from ? { validFrom: row.valid_from } : {}),
+        ...(row.valid_to ? { validTo: row.valid_to } : {}),
+        sourceEventIds: sourcesByFact.get(row.id) ?? [],
+        ...(row.confidence === null ? {} : { confidence: row.confidence }),
+        status: row.status,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      });
+      factsByElement.set(row.element_id, facts);
+    }
+
+    const elementRows = this.database.prepare(`
+      SELECT * FROM elements WHERE namespace = ? ORDER BY position
+    `).all(key) as ElementRow[];
+    const messagesByEvent = new Map(events.map((event) => [event.id, event.sourceMessageIds]));
+    const elements: ElementCard[] = elementRows.map((row) => {
+      const sourceEventIds = sourcesByElement.get(row.id) ?? [];
+      return {
+        id: row.id,
+        name: row.name,
+        type: row.type,
+        aliases: parseJson<string[]>(row.aliases_json, 'elements.aliases_json'),
+        currentState: row.current_state,
+        facts: factsByElement.get(row.id) ?? [],
+        sourceEventIds,
+        sourceMessageIds: [...new Set(sourceEventIds.flatMap((id) => messagesByEvent.get(id) ?? []))],
+        weight: {
+          mentionCount: row.mention_count,
+          lastAdoptedTurn: row.last_adopted_turn,
+          lastRetrievedAt: row.last_retrieved_at,
+          pinned: Boolean(row.pinned),
+          floorWeight: row.floor_weight,
+          forcedCap: row.forced_cap,
+        },
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      };
+    });
+
     const extractionJobs = (this.database.prepare(`
       SELECT block_id, status, attempts, last_error, updated_at
       FROM extraction_jobs WHERE namespace = ? ORDER BY block_id
@@ -366,12 +575,28 @@ export class SqliteStorage implements StorageAdapter {
       updatedAt: row.updated_at,
     }));
 
+    const elementProjectionJobs = (this.database.prepare(`
+      SELECT id, source_event_ids_json, status, attempts, element_ids_json, reason, last_error, created_at, updated_at
+      FROM element_projection_jobs WHERE namespace = ? ORDER BY created_at, id
+    `).all(key) as ElementProjectionJobRow[]).map<ElementProjectionJob>((row) => ({
+      id: row.id,
+      sourceEventIds: parseJson<string[]>(row.source_event_ids_json, 'element_projection_jobs.source_event_ids_json'),
+      status: row.status,
+      attempts: row.attempts,
+      elementIds: parseJson<string[]>(row.element_ids_json, 'element_projection_jobs.element_ids_json'),
+      reason: row.reason,
+      lastError: row.last_error,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+
     const usageReceipts = (this.database.prepare(`
-      SELECT receipt_id, event_ids_json, created_at
+      SELECT receipt_id, event_ids_json, element_ids_json, created_at
       FROM usage_receipts WHERE namespace = ? ORDER BY created_at, receipt_id
     `).all(key) as UsageReceiptRow[]).map<UsageReceipt>((row) => ({
       id: row.receipt_id,
       eventIds: parseJson<string[]>(row.event_ids_json, 'usage_receipts.event_ids_json'),
+      elementIds: parseJson<string[]>(row.element_ids_json, 'usage_receipts.element_ids_json'),
       createdAt: row.created_at,
     }));
 
@@ -382,7 +607,9 @@ export class SqliteStorage implements StorageAdapter {
       openTail,
       blocks,
       events,
+      elements,
       extractionJobs,
+      elementProjectionJobs,
       usageReceipts,
     };
     assertValidSnapshot(snapshot);
@@ -584,6 +811,94 @@ export class SqliteStorage implements StorageAdapter {
       }
     }
 
+    const insertElement = this.database.prepare(`
+      INSERT INTO elements (
+        namespace, id, position, name, type, aliases_json, current_state,
+        mention_count, last_adopted_turn, last_retrieved_at, pinned, floor_weight, forced_cap,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (namespace, id) DO UPDATE SET
+        position = excluded.position,
+        name = excluded.name,
+        type = excluded.type,
+        aliases_json = excluded.aliases_json,
+        current_state = excluded.current_state,
+        mention_count = excluded.mention_count,
+        last_adopted_turn = excluded.last_adopted_turn,
+        last_retrieved_at = excluded.last_retrieved_at,
+        pinned = excluded.pinned,
+        floor_weight = excluded.floor_weight,
+        forced_cap = excluded.forced_cap,
+        updated_at = excluded.updated_at
+    `);
+    const insertElementSource = this.database.prepare(`
+      INSERT INTO element_sources (namespace, element_id, event_id, position) VALUES (?, ?, ?, ?)
+      ON CONFLICT (namespace, element_id, event_id) DO UPDATE SET position = excluded.position
+    `);
+    const insertElementFact = this.database.prepare(`
+      INSERT INTO element_facts (
+        namespace, id, element_id, position, key, mode, value_json, valid_from, valid_to,
+        confidence, status, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (namespace, id) DO UPDATE SET
+        element_id = excluded.element_id,
+        position = excluded.position,
+        key = excluded.key,
+        mode = excluded.mode,
+        value_json = excluded.value_json,
+        valid_from = excluded.valid_from,
+        valid_to = excluded.valid_to,
+        confidence = excluded.confidence,
+        status = excluded.status,
+        updated_at = excluded.updated_at
+    `);
+    const insertElementFactSource = this.database.prepare(`
+      INSERT INTO element_fact_sources (namespace, fact_id, event_id, position) VALUES (?, ?, ?, ?)
+      ON CONFLICT (namespace, fact_id, event_id) DO UPDATE SET position = excluded.position
+    `);
+    for (const [elementPosition, element] of snapshot.elements.entries()) {
+      insertElement.run(
+        namespace,
+        element.id,
+        elementPosition,
+        element.name,
+        element.type,
+        JSON.stringify(element.aliases),
+        element.currentState,
+        element.weight.mentionCount,
+        element.weight.lastAdoptedTurn,
+        element.weight.lastRetrievedAt,
+        Number(element.weight.pinned),
+        element.weight.floorWeight,
+        element.weight.forcedCap,
+        element.createdAt,
+        element.updatedAt,
+      );
+      for (const [position, eventId] of element.sourceEventIds.entries()) {
+        insertElementSource.run(namespace, element.id, eventId, position);
+      }
+      for (const [factPosition, fact] of element.facts.entries()) {
+        insertElementFact.run(
+          namespace,
+          fact.id,
+          element.id,
+          factPosition,
+          fact.key,
+          fact.mode,
+          JSON.stringify(fact.value),
+          fact.validFrom ?? null,
+          fact.validTo ?? null,
+          fact.confidence ?? null,
+          fact.status,
+          fact.createdAt,
+          fact.updatedAt,
+        );
+        for (const [position, eventId] of fact.sourceEventIds.entries()) {
+          insertElementFactSource.run(namespace, fact.id, eventId, position);
+        }
+      }
+    }
+
     const insertJob = this.database.prepare(`
       INSERT INTO extraction_jobs (
         namespace, block_id, status, attempts, last_error, updated_at
@@ -598,13 +913,48 @@ export class SqliteStorage implements StorageAdapter {
       insertJob.run(namespace, job.blockId, job.status, job.attempts, job.lastError, job.updatedAt);
     }
 
+    const insertElementProjectionJob = this.database.prepare(`
+      INSERT INTO element_projection_jobs (
+        namespace, id, source_event_ids_json, status, attempts, element_ids_json,
+        reason, last_error, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (namespace, id) DO UPDATE SET
+        source_event_ids_json = excluded.source_event_ids_json,
+        status = excluded.status,
+        attempts = excluded.attempts,
+        element_ids_json = excluded.element_ids_json,
+        reason = excluded.reason,
+        last_error = excluded.last_error,
+        updated_at = excluded.updated_at
+    `);
+    for (const job of snapshot.elementProjectionJobs) {
+      insertElementProjectionJob.run(
+        namespace,
+        job.id,
+        JSON.stringify(job.sourceEventIds),
+        job.status,
+        job.attempts,
+        JSON.stringify(job.elementIds),
+        job.reason,
+        job.lastError,
+        job.createdAt,
+        job.updatedAt,
+      );
+    }
+
     const insertReceipt = this.database.prepare(`
-      INSERT INTO usage_receipts (namespace, receipt_id, event_ids_json, created_at)
-      VALUES (?, ?, ?, ?)
+      INSERT INTO usage_receipts (namespace, receipt_id, event_ids_json, element_ids_json, created_at)
+      VALUES (?, ?, ?, ?, ?)
       ON CONFLICT (namespace, receipt_id) DO NOTHING
     `);
     for (const receipt of snapshot.usageReceipts) {
-      insertReceipt.run(namespace, receipt.id, JSON.stringify(receipt.eventIds), receipt.createdAt);
+      insertReceipt.run(
+        namespace,
+        receipt.id,
+        JSON.stringify(receipt.eventIds),
+        JSON.stringify(receipt.elementIds),
+        receipt.createdAt,
+      );
     }
 
     return nextRevision;
@@ -618,6 +968,18 @@ export class SqliteStorage implements StorageAdapter {
     if (version === 0) {
       const migrate = this.database.transaction(() => {
         this.database.exec(SCHEMA);
+        this.database.pragma(`user_version = ${STRATAGATE_STORAGE_SCHEMA_VERSION}`);
+      });
+      migrate.immediate();
+    } else if (version === 1) {
+      const migrate = this.database.transaction(() => {
+        const receiptColumns = this.database.pragma('table_info(usage_receipts)') as Array<{ name: string }>;
+        if (!receiptColumns.some(({ name }) => name === 'element_ids_json')) {
+          this.database.exec("ALTER TABLE usage_receipts ADD COLUMN element_ids_json TEXT NOT NULL DEFAULT '[]'");
+        }
+        this.database.exec(SCHEMA);
+        this.database.prepare('UPDATE memory_spaces SET schema_version = ? WHERE schema_version = 1')
+          .run(STRATAGATE_STORAGE_SCHEMA_VERSION);
         this.database.pragma(`user_version = ${STRATAGATE_STORAGE_SCHEMA_VERSION}`);
       });
       migrate.immediate();

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,6 @@
-import type { EventCard, MemoryBlock, RawMessage } from './types.js';
+import type { ElementCard, EventCard, MemoryBlock, RawMessage } from './types.js';
 
-export const STRATAGATE_STORAGE_SCHEMA_VERSION = 1;
+export const STRATAGATE_STORAGE_SCHEMA_VERSION = 2;
 
 export type ExtractionJobStatus = 'running' | 'succeeded' | 'skipped' | 'failed';
 
@@ -12,9 +12,24 @@ export interface ExtractionJob {
   updatedAt: string;
 }
 
+export type ElementProjectionJobStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface ElementProjectionJob {
+  id: string;
+  sourceEventIds: string[];
+  status: ElementProjectionJobStatus;
+  attempts: number;
+  elementIds: string[];
+  reason: string | null;
+  lastError: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface UsageReceipt {
   id: string;
   eventIds: string[];
+  elementIds: string[];
   createdAt: string;
 }
 
@@ -25,7 +40,9 @@ export interface StrataGateSnapshot {
   openTail: RawMessage[];
   blocks: MemoryBlock[];
   events: EventCard[];
+  elements: ElementCard[];
   extractionJobs: ExtractionJob[];
+  elementProjectionJobs: ElementProjectionJob[];
   usageReceipts: UsageReceipt[];
 }
 
@@ -55,11 +72,30 @@ export function cloneSnapshot(snapshot: StrataGateSnapshot): StrataGateSnapshot 
   return structuredClone(snapshot);
 }
 
-export function assertValidSnapshot(value: unknown): asserts value is StrataGateSnapshot {
+interface LegacySnapshotV1 extends Omit<StrataGateSnapshot, 'schemaVersion' | 'elements' | 'elementProjectionJobs' | 'usageReceipts'> {
+  schemaVersion: 1;
+  usageReceipts: Array<Omit<UsageReceipt, 'elementIds'>>;
+}
+
+export function normalizeSnapshot(value: unknown): StrataGateSnapshot {
   if (!value || typeof value !== 'object') throw new TypeError('Invalid StrataGate snapshot: expected an object');
-  const snapshot = value as Partial<StrataGateSnapshot>;
-  if (snapshot.schemaVersion !== STRATAGATE_STORAGE_SCHEMA_VERSION) {
-    throw new TypeError(`Unsupported StrataGate snapshot schema: ${String(snapshot.schemaVersion)}`);
+  const schemaVersion = (value as { schemaVersion?: unknown }).schemaVersion;
+  let snapshot: StrataGateSnapshot;
+  if (schemaVersion === 1) {
+    const legacy = value as LegacySnapshotV1;
+    snapshot = {
+      ...structuredClone(legacy),
+      schemaVersion: STRATAGATE_STORAGE_SCHEMA_VERSION,
+      elements: [],
+      elementProjectionJobs: [],
+      usageReceipts: Array.isArray(legacy.usageReceipts)
+        ? legacy.usageReceipts.map((receipt) => ({ ...receipt, elementIds: [] }))
+        : [],
+    };
+  } else if (schemaVersion === STRATAGATE_STORAGE_SCHEMA_VERSION) {
+    snapshot = structuredClone(value) as StrataGateSnapshot;
+  } else {
+    throw new TypeError(`Unsupported StrataGate snapshot schema: ${String(schemaVersion)}`);
   }
   if (!Number.isSafeInteger(snapshot.currentTurn) || (snapshot.currentTurn ?? -1) < 0) {
     throw new TypeError('Invalid StrataGate snapshot: currentTurn must be a non-negative integer');
@@ -67,7 +103,12 @@ export function assertValidSnapshot(value: unknown): asserts value is StrataGate
   if (!Number.isSafeInteger(snapshot.blockTurnSize) || (snapshot.blockTurnSize ?? 0) < 1) {
     throw new TypeError('Invalid StrataGate snapshot: blockTurnSize must be a positive integer');
   }
-  for (const key of ['openTail', 'blocks', 'events', 'extractionJobs', 'usageReceipts'] as const) {
+  for (const key of ['openTail', 'blocks', 'events', 'elements', 'extractionJobs', 'elementProjectionJobs', 'usageReceipts'] as const) {
     if (!Array.isArray(snapshot[key])) throw new TypeError(`Invalid StrataGate snapshot: ${key} must be an array`);
   }
+  return snapshot;
+}
+
+export function assertValidSnapshot(value: unknown): asserts value is StrataGateSnapshot {
+  normalizeSnapshot(value);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,11 +5,21 @@ import {
   getDecayedBlockLevel,
   normalizeBlockLevel,
 } from './blocks.js';
+import { applyElementChanges, elementViewAt } from './elements.js';
 import { normalizeRetrievalAssessment, type RetrievalAssessment, type RetrievalAssessmentInput } from './retrieval.js';
 import {
+  bm25Rank,
+  fuzzySearchMatch,
+  normalizeSearchText,
+  rrfRank,
+  searchTokens,
+  weightedSearchTokens,
+} from './search.js';
+import {
   STRATAGATE_STORAGE_SCHEMA_VERSION,
-  assertValidSnapshot,
   cloneSnapshot,
+  normalizeSnapshot,
+  type ElementProjectionJob,
   type ExtractionJob,
   type StorageAdapter,
   type StrataGateSnapshot,
@@ -19,6 +29,12 @@ import type {
   AppendTurnResult,
   BlockLevel,
   BlockSummarizer,
+  ElementCard,
+  ElementProjectionContext,
+  ElementProjectionResult,
+  ElementProjector,
+  ElementSearchOptions,
+  ElementSearchResult,
   EventCard,
   EventCardInput,
   EventExtractor,
@@ -35,8 +51,10 @@ export interface StrataGateOptions {
   blockTurnSize?: number;
   summarizer?: BlockSummarizer;
   extractor?: EventExtractor;
+  elementProjector?: ElementProjector;
   now?: () => Date;
   idFactory?: (prefix: 'msg' | 'blk' | 'evt') => string;
+  elementIdFactory?: (prefix: 'elem' | 'fact' | 'proj') => string;
 }
 
 export interface PersistentStrataGateOptions extends StrataGateOptions {
@@ -64,12 +82,22 @@ export interface RecordMemoryUseOptions {
   receiptId?: string;
 }
 
+export interface MemoryUseRefs {
+  eventIds?: readonly string[];
+  elementIds?: readonly string[];
+}
+
 export interface ResumePendingResult {
   sealedBlocks: MemoryBlock[];
   extractedEvents: EventCard[];
+  projectedElements: ElementCard[];
 }
 
 function defaultIdFactory(prefix: 'msg' | 'blk' | 'evt'): string {
+  return `${prefix}_${crypto.randomUUID()}`;
+}
+
+function defaultElementIdFactory(prefix: 'elem' | 'fact' | 'proj'): string {
   return `${prefix}_${crypto.randomUUID()}`;
 }
 
@@ -89,18 +117,6 @@ function defaultSummary(messages: readonly RawMessage[]): {
     l2Keypoints: natural.slice(0, 8).map((message) => message.content.replace(/\s+/g, ' ').trim().slice(0, 160)),
     shouldExtract: false,
   };
-}
-
-function normalizeText(value: string): string {
-  return value.toLocaleLowerCase().normalize('NFKC');
-}
-
-function queryTokens(value: string): string[] {
-  const normalized = normalizeText(value);
-  const words = normalized.match(/[\p{L}\p{N}_-]+/gu) ?? [];
-  const cjkRuns = normalized.match(/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]+/gu) ?? [];
-  const bigrams = cjkRuns.flatMap((run) => Array.from({ length: Math.max(0, run.length - 1) }, (_, index) => run.slice(index, index + 2)));
-  return [...new Set([...words, ...bigrams].filter((token) => token.length > 1))];
 }
 
 function renderBlock(block: MemoryBlock, level: BlockLevel): string {
@@ -125,12 +141,16 @@ export class StrataGate {
 
   private readonly summarizer: BlockSummarizer | undefined;
   private readonly extractor: EventExtractor | undefined;
+  private readonly elementProjector: ElementProjector | undefined;
   private readonly now: () => Date;
   private readonly idFactory: (prefix: 'msg' | 'blk' | 'evt') => string;
+  private readonly elementIdFactory: (prefix: 'elem' | 'fact' | 'proj') => string;
   private readonly openTail: RawMessage[] = [];
   private readonly blocks: MemoryBlock[] = [];
   private readonly events: EventCard[] = [];
+  private readonly elements: ElementCard[] = [];
   private readonly extractionJobs = new Map<string, ExtractionJob>();
+  private readonly elementProjectionJobs = new Map<string, ElementProjectionJob>();
   private readonly usageReceipts = new Map<string, UsageReceipt>();
   private currentTurn = 0;
   private storage: StorageAdapter | undefined;
@@ -142,32 +162,37 @@ export class StrataGate {
     this.blockTurnSize = Math.max(1, Math.floor(options.blockTurnSize ?? DEFAULT_BLOCK_TURN_SIZE));
     this.summarizer = options.summarizer;
     this.extractor = options.extractor;
+    this.elementProjector = options.elementProjector;
     this.now = options.now ?? (() => new Date());
     this.idFactory = options.idFactory ?? defaultIdFactory;
+    this.elementIdFactory = options.elementIdFactory ?? defaultElementIdFactory;
   }
 
   static async open(options: PersistentStrataGateOptions): Promise<StrataGate> {
     const namespace = options.namespace.trim();
     if (!namespace) throw new TypeError('Storage namespace must not be empty');
     const loaded = await options.storage.load(namespace);
+    const loadedSnapshot = loaded ? normalizeSnapshot(loaded.snapshot) : null;
     if (loaded && options.blockTurnSize !== undefined) {
       const requested = Math.max(1, Math.floor(options.blockTurnSize));
-      if (requested !== loaded.snapshot.blockTurnSize) {
-        throw new Error(`Stored blockTurnSize is ${loaded.snapshot.blockTurnSize}, but ${requested} was requested`);
+      if (requested !== loadedSnapshot?.blockTurnSize) {
+        throw new Error(`Stored blockTurnSize is ${loadedSnapshot?.blockTurnSize}, but ${requested} was requested`);
       }
     }
     const memoryOptions: StrataGateOptions = {};
-    if (loaded) memoryOptions.blockTurnSize = loaded.snapshot.blockTurnSize;
+    if (loadedSnapshot) memoryOptions.blockTurnSize = loadedSnapshot.blockTurnSize;
     else if (options.blockTurnSize !== undefined) memoryOptions.blockTurnSize = options.blockTurnSize;
     if (options.summarizer) memoryOptions.summarizer = options.summarizer;
     if (options.extractor) memoryOptions.extractor = options.extractor;
+    if (options.elementProjector) memoryOptions.elementProjector = options.elementProjector;
     if (options.now) memoryOptions.now = options.now;
     if (options.idFactory) memoryOptions.idFactory = options.idFactory;
+    if (options.elementIdFactory) memoryOptions.elementIdFactory = options.elementIdFactory;
     const memory = new StrataGate(memoryOptions);
     memory.storage = options.storage;
     memory.namespace = namespace;
-    if (loaded) {
-      memory.restoreSnapshot(loaded.snapshot);
+    if (loaded && loadedSnapshot) {
+      memory.restoreSnapshot(loadedSnapshot);
       memory.revision = loaded.revision;
       const interrupted = [...memory.extractionJobs.values()].filter((job) => job.status === 'running');
       if (interrupted.length > 0) {
@@ -178,6 +203,21 @@ export class StrataGate {
               ...job,
               status: 'failed',
               lastError: 'Extraction was interrupted before completion.',
+              updatedAt: now,
+            });
+          }
+        });
+      }
+      const interruptedProjections = [...memory.elementProjectionJobs.values()]
+        .filter((job) => job.status === 'running');
+      if (interruptedProjections.length > 0) {
+        await memory.commitMutation(() => {
+          const now = memory.now().toISOString();
+          for (const job of interruptedProjections) {
+            memory.elementProjectionJobs.set(job.id, {
+              ...job,
+              status: 'failed',
+              lastError: 'Element projection was interrupted before completion.',
               updatedAt: now,
             });
           }
@@ -205,12 +245,20 @@ export class StrataGate {
     return this.events;
   }
 
+  listElements(): readonly ElementCard[] {
+    return this.elements;
+  }
+
   listOpenTail(): readonly RawMessage[] {
     return this.openTail;
   }
 
   listExtractionJobs(): readonly ExtractionJob[] {
     return [...this.extractionJobs.values()];
+  }
+
+  listElementProjectionJobs(): readonly ElementProjectionJob[] {
+    return [...this.elementProjectionJobs.values()];
   }
 
   exportSnapshot(): StrataGateSnapshot {
@@ -221,7 +269,9 @@ export class StrataGate {
       openTail: this.openTail,
       blocks: this.blocks,
       events: this.events,
+      elements: this.elements,
       extractionJobs: [...this.extractionJobs.values()],
+      elementProjectionJobs: [...this.elementProjectionJobs.values()],
       usageReceipts: [...this.usageReceipts.values()],
     });
   }
@@ -248,70 +298,110 @@ export class StrataGate {
     });
 
     if (this.openTail.filter((message) => message.role === 'user').length < this.blockTurnSize) {
-      return { sealedBlock: null, extractedEvents: [] };
+      const projectedElements = await this.projectEligibleElements() ?? [];
+      return { sealedBlock: null, extractedEvents: [], projectedElements };
     }
 
     const sealedBlock = await this.sealOpenTail();
     const extractedEvents = await this.extractEligibleBlock() ?? [];
-    return { sealedBlock, extractedEvents };
+    const projectedElements = await this.projectEligibleElements() ?? [];
+    return { sealedBlock, extractedEvents, projectedElements };
   }
 
   async resumePendingWork(): Promise<ResumePendingResult> {
     const sealedBlocks: MemoryBlock[] = [];
     const extractedEvents: EventCard[] = [];
+    const projectedElements: ElementCard[] = [];
     while (this.openTail.filter((message) => message.role === 'user').length >= this.blockTurnSize) {
       sealedBlocks.push(await this.sealOpenTail());
       extractedEvents.push(...(await this.extractEligibleBlock() ?? []));
+      projectedElements.push(...(await this.projectEligibleElements() ?? []));
     }
     while (true) {
       const extracted = await this.extractEligibleBlock();
       if (extracted === null) break;
       extractedEvents.push(...extracted);
+      projectedElements.push(...(await this.projectEligibleElements() ?? []));
     }
-    return { sealedBlocks, extractedEvents };
+    while (true) {
+      const projected = await this.projectEligibleElements();
+      if (projected === null) break;
+      projectedElements.push(...projected);
+    }
+    return { sealedBlocks, extractedEvents, projectedElements };
   }
 
   async addEvent(input: EventCardInput): Promise<EventCard> {
-    return this.commitMutation(() => this.addEventInMemory(input));
+    return this.commitMutation(() => {
+      const event = this.addEventInMemory(input);
+      this.queueElementProjection([event.id]);
+      return event;
+    });
   }
 
   async searchEvents(query: string, options: SearchOptions = {}): Promise<EventSearchResult[]> {
-    const tokens = queryTokens(query);
-    const participants = (options.participants ?? []).map(normalizeText);
-    const eventType = options.eventType ? normalizeText(options.eventType) : null;
-    const ranked = this.events
-      .filter((event) => event.status === 'active' || event.status === 'superseded')
-      .filter((event) => participants.length === 0 || participants.every((person) =>
-        (event.temporal.participants ?? []).some((candidate) => normalizeText(candidate).includes(person))))
-      .filter((event) => !eventType || normalizeText(event.temporal.eventType ?? '').includes(eventType))
-      .map((event) => {
-        const temporal = event.temporal;
-        const searchable = normalizeText([
-          event.title,
-          event.summary,
-          event.narrative,
-          ...event.tags,
-          ...event.quotes,
-          ...(temporal.participants ?? []),
-          temporal.eventType ?? '',
-          temporal.happenedStart ?? '',
-          temporal.happenedEnd ?? '',
-          temporal.originalText ?? '',
-        ].join(' '));
-        const matched = tokens.filter((token) => searchable.includes(token)).length;
-        const lexical = tokens.length === 0 ? 0 : matched / tokens.length;
-        const timeBonus = options.temporalIntent && /(\d{4}|when|before|after|first|last|何时|什么时候|之前|之后|最早|最近)/iu.test(query)
-          && Boolean(temporal.happenedStart || temporal.happenedEnd) ? 0.2 : 0;
-        const statusPenalty = event.status === 'superseded' ? -0.25 : 0;
-        return { event, score: lexical * 2 + memoryWeightAt(event, this.currentTurn) + timeBonus + statusPenalty };
-      })
-      .filter(({ score }) => tokens.length === 0 || score > 0)
-      .sort((a, b) => b.score - a.score)
-      .slice(0, Math.max(1, Math.min(20, options.limit ?? 6)));
-
-    if (options.temporalIntent) {
-      ranked.sort((a, b) => (a.event.temporal.happenedStart ?? '').localeCompare(b.event.temporal.happenedStart ?? ''));
+    const limit = Math.max(1, Math.min(20, options.limit ?? 6));
+    const participants = (options.participants ?? []).map(normalizeSearchText).filter(Boolean);
+    const eventType = normalizeSearchText(options.eventType ?? '');
+    const from = options.happenedFrom ? Date.parse(options.happenedFrom) : Number.NEGATIVE_INFINITY;
+    const to = options.happenedTo ? Date.parse(options.happenedTo) : Number.POSITIVE_INFINITY;
+    const hasTimeFilter = Boolean(options.happenedFrom || options.happenedTo);
+    const candidates = this.events.filter((event) => event.status === 'active' || event.status === 'superseded');
+    const participantMatches = candidates.filter((event) => participants.length > 0 && participants.every((person) =>
+      (event.temporal.participants ?? []).some((candidate) => fuzzySearchMatch(candidate, person))));
+    const typeMatches = eventType ? candidates.filter((event) =>
+      fuzzySearchMatch(event.temporal.eventType ?? '', eventType)
+      || fuzzySearchMatch(`${event.title} ${event.summary} ${event.tags.join(' ')}`, eventType)) : [];
+    const timeMatches = hasTimeFilter ? candidates.filter((event) => {
+      const start = Date.parse(event.temporal.happenedStart ?? event.temporal.happenedEnd ?? '');
+      const end = Date.parse(event.temporal.happenedEnd ?? event.temporal.happenedStart ?? '');
+      return Number.isFinite(start) && Number.isFinite(end) && start <= to && end >= from;
+    }) : [];
+    const bm25 = bm25Rank(candidates, query, (event) => weightedSearchTokens([
+      [event.title, 4],
+      [event.summary, 3],
+      [event.tags.join(' '), 2],
+      [event.quotes.join(' '), 2],
+      [event.narrative, 1],
+      [(event.temporal.participants ?? []).join(' '), 5],
+      [event.temporal.eventType ?? '', 5],
+      [event.temporal.originalText ?? '', 4],
+      [`${event.temporal.happenedStart ?? ''} ${event.temporal.happenedEnd ?? ''}`, 4],
+    ])).map(({ item }) => item);
+    const chronology = (event: EventCard): string => event.temporal.happenedStart
+      ?? event.temporal.happenedEnd
+      ?? event.temporal.mentionedAt
+      ?? event.createdAt;
+    const structured = (items: readonly EventCard[]): EventCard[] => [...items].sort((left, right) => {
+      if (options.temporalIntent === 'first') return chronology(left).localeCompare(chronology(right));
+      if (options.temporalIntent === 'latest') return chronology(right).localeCompare(chronology(left));
+      return memoryWeightAt(right, this.currentTurn) - memoryWeightAt(left, this.currentTurn)
+        || right.updatedAt.localeCompare(left.updatedAt);
+    });
+    const participantIds = new Set(participantMatches.map(({ id }) => id));
+    const typeIds = new Set(typeMatches.map(({ id }) => id));
+    const timeIds = new Set(timeMatches.map(({ id }) => id));
+    const hasStructuredFilter = participants.length > 0 || Boolean(eventType) || hasTimeFilter;
+    const exactStructuredMatches = hasStructuredFilter ? candidates.filter((event) =>
+      (participants.length === 0 || participantIds.has(event.id))
+      && (!eventType || typeIds.has(event.id))
+      && (!hasTimeFilter || timeIds.has(event.id))) : [];
+    const rankings: EventCard[][] = [];
+    if (exactStructuredMatches.length > 0) {
+      const exactIds = new Set(exactStructuredMatches.map(({ id }) => id));
+      rankings.push(bm25.filter(({ id }) => exactIds.has(id)), structured(exactStructuredMatches));
+    } else {
+      rankings.push(bm25);
+      if (participantMatches.length > 0) rankings.push(structured(participantMatches));
+      if (typeMatches.length > 0) rankings.push(structured(typeMatches));
+      if (timeMatches.length > 0) rankings.push(structured(timeMatches));
     }
+    if (searchTokens(query).length > 0 && bm25.length === 0 && !hasStructuredFilter) return [];
+    if (!rankings.some((ranking) => ranking.length > 0)) {
+      if (searchTokens(query).length > 0) return [];
+      rankings.push(structured(candidates));
+    }
+    const ranked = rrfRank(rankings).slice(0, limit).map(({ item: event, score }) => ({ event, score }));
     if (ranked.length > 0) {
       const now = this.now().toISOString();
       await this.commitMutation(() => {
@@ -321,14 +411,141 @@ export class StrataGate {
     return ranked;
   }
 
+  async claimNextElementProjection(): Promise<ElementProjectionContext | null> {
+    return this.commitMutation(() => {
+      const job = [...this.elementProjectionJobs.values()]
+        .find((candidate) => candidate.status === 'pending' || candidate.status === 'failed');
+      if (!job) return null;
+      const events = job.sourceEventIds.flatMap((id) => this.events.find((event) => event.id === id) ?? []);
+      if (events.length === 0) {
+        throw new Error(`Element projection ${job.id} has no available source events`);
+      }
+      job.status = 'running';
+      job.attempts += 1;
+      job.lastError = null;
+      job.updatedAt = this.now().toISOString();
+      return {
+        jobId: job.id,
+        events: structuredClone(events),
+        existingElements: structuredClone(this.elements),
+      };
+    });
+  }
+
+  async completeElementProjection(jobId: string, result: ElementProjectionResult): Promise<ElementCard[]> {
+    return this.commitMutation(() => {
+      const job = this.requireElementProjectionJob(jobId);
+      if (job.status === 'completed') {
+        return job.elementIds.flatMap((id) => this.elements.find((element) => element.id === id) ?? []);
+      }
+      if (job.status !== 'running') throw new Error(`Element projection ${job.id} is ${job.status}, not running`);
+      const touched = applyElementChanges({
+        elements: this.elements,
+        events: this.events,
+        changes: Array.isArray(result.changes) ? result.changes : [],
+        allowedEventIds: new Set(job.sourceEventIds),
+        now: this.now().toISOString(),
+        currentTurn: this.currentTurn,
+        idFactory: this.elementIdFactory,
+      });
+      job.status = 'completed';
+      job.elementIds = touched.map(({ id }) => id);
+      job.reason = typeof result.reason === 'string'
+        ? result.reason.trim().replace(/\s+/g, ' ').slice(0, 500) || null
+        : null;
+      job.lastError = null;
+      job.updatedAt = this.now().toISOString();
+      return touched;
+    });
+  }
+
+  async failElementProjection(jobId: string, error: unknown): Promise<void> {
+    await this.commitMutation(() => {
+      const job = this.requireElementProjectionJob(jobId);
+      if (job.status === 'completed') return;
+      job.status = 'failed';
+      job.lastError = errorMessage(error);
+      job.updatedAt = this.now().toISOString();
+    });
+  }
+
+  async searchElements(query: string, options: ElementSearchOptions = {}): Promise<ElementSearchResult[]> {
+    const normalizedName = normalizeSearchText(options.name ?? '');
+    const candidates = this.elements.flatMap((element) => element.facts.map((fact) => ({
+      id: fact.id,
+      elementId: element.id,
+      name: element.name,
+      aliases: element.aliases,
+      type: element.type,
+      fact,
+      updatedAt: element.updatedAt,
+    })));
+    const bm25 = bm25Rank(candidates, query, (hit) => weightedSearchTokens([
+      [hit.name, 5],
+      [hit.aliases.join(' '), 4],
+      [hit.type, 2],
+      [hit.fact.key, 4],
+      [Array.isArray(hit.fact.value) ? hit.fact.value.join(' ') : hit.fact.value, 5],
+    ])).map(({ item }) => item);
+    const nameMatches = normalizedName ? candidates.filter((hit) =>
+      fuzzySearchMatch(hit.name, normalizedName)
+      || hit.aliases.some((alias) => fuzzySearchMatch(alias, normalizedName))) : [];
+    const typeMatches = options.type ? candidates.filter((hit) => hit.type === options.type) : [];
+    const recent = (items: typeof candidates): typeof candidates => [...items]
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.id.localeCompare(right.id));
+    const hasStructuredFilter = Boolean(normalizedName || options.type);
+    const nameIds = new Set(nameMatches.map(({ id }) => id));
+    const typeIds = new Set(typeMatches.map(({ id }) => id));
+    const exactStructuredMatches = hasStructuredFilter ? candidates.filter((hit) =>
+      (!normalizedName || nameIds.has(hit.id)) && (!options.type || typeIds.has(hit.id))) : [];
+    const rankings: typeof candidates[] = [];
+    if (exactStructuredMatches.length > 0) {
+      const exactIds = new Set(exactStructuredMatches.map(({ id }) => id));
+      rankings.push(bm25.filter(({ id }) => exactIds.has(id)), recent(exactStructuredMatches));
+    } else {
+      rankings.push(bm25);
+      if (nameMatches.length > 0) rankings.push(recent(nameMatches));
+      if (typeMatches.length > 0) rankings.push(recent(typeMatches));
+    }
+    if (searchTokens(query).length > 0 && bm25.length === 0 && !hasStructuredFilter) return [];
+    if (!rankings.some((ranking) => ranking.length > 0)) {
+      if (searchTokens(query).length > 0) return [];
+      rankings.push(recent(candidates));
+    }
+    const ranked = rrfRank(rankings).slice(0, Math.max(1, Math.min(12, options.limit ?? 8)));
+    if (ranked.length > 0) {
+      const now = this.now().toISOString();
+      await this.commitMutation(() => {
+        for (const elementId of new Set(ranked.map(({ item }) => item.elementId))) {
+          const element = this.elements.find(({ id }) => id === elementId);
+          if (element) element.weight.lastRetrievedAt = now;
+        }
+      });
+    }
+    return ranked.map(({ item, score }) => ({
+      id: item.id,
+      elementId: item.elementId,
+      name: item.name,
+      type: item.type,
+      fact: item.fact,
+      score,
+    }));
+  }
+
+  expandElement(id: string, at?: string): ElementCard {
+    const element = this.elements.find((candidate) => candidate.id === id);
+    if (!element) throw new Error(`Unknown element: ${id}`);
+    return elementViewAt(element, at);
+  }
+
   searchRawMemory(query: string, limit = 6): RawSearchHit[] {
-    const tokens = queryTokens(query);
+    const tokens = searchTokens(query);
     if (tokens.length === 0) return [];
     const hits: RawSearchHit[] = [];
     for (const block of this.blocks) {
       for (const [index, message] of block.l5Raw.entries()) {
-        const text = normalizeText(message.content);
-        if (!tokens.some((token) => text.includes(token))) continue;
+        const messageTokens = new Set(searchTokens(message.content));
+        if (!tokens.some((token) => messageTokens.has(token))) continue;
         hits.push({
           blockId: block.id,
           turnRange: [block.startTurn, block.endTurn],
@@ -379,15 +596,20 @@ export class StrataGate {
     return normalizeRetrievalAssessment(input, latestEvidenceRefs);
   }
 
-  async recordMemoryUse(eventIds: readonly string[], options: RecordMemoryUseOptions = {}): Promise<void> {
+  async recordMemoryUse(refs: readonly string[] | MemoryUseRefs, options: RecordMemoryUseOptions = {}): Promise<void> {
     const receiptId = options.receiptId?.trim();
     if (this.storage && !receiptId) throw new TypeError('Persistent recordMemoryUse requires a non-empty receiptId');
-    const requestedIds = [...new Set(eventIds)];
+    const normalizedRefs: MemoryUseRefs = Array.isArray(refs)
+      ? { eventIds: refs as readonly string[] }
+      : refs as MemoryUseRefs;
+    const requestedEventIds = [...new Set(normalizedRefs.eventIds ?? [])];
+    const requestedElementIds = [...new Set(normalizedRefs.elementIds ?? [])];
     if (receiptId) {
       const existing = this.usageReceipts.get(receiptId);
       if (existing) {
-        if (!sameIds(existing.eventIds, requestedIds)) {
-          throw new Error(`Usage receipt ${receiptId} was already recorded with different event IDs`);
+        if (!sameIds(existing.eventIds, requestedEventIds)
+          || !sameIds(existing.elementIds, requestedElementIds)) {
+          throw new Error(`Usage receipt ${receiptId} was already recorded with different memory IDs`);
         }
         return;
       }
@@ -395,14 +617,26 @@ export class StrataGate {
 
     await this.commitMutation(() => {
       const now = this.now().toISOString();
-      for (const id of requestedIds) {
+      for (const id of requestedEventIds) {
         const event = this.events.find((candidate) => candidate.id === id);
         if (!event || event.status === 'forgotten' || event.status === 'archived') continue;
         event.weight.mentionCount += 1;
         event.weight.lastAdoptedTurn = this.currentTurn;
         event.updatedAt = now;
       }
-      if (receiptId) this.usageReceipts.set(receiptId, { id: receiptId, eventIds: requestedIds, createdAt: now });
+      for (const id of requestedElementIds) {
+        const element = this.elements.find((candidate) => candidate.id === id);
+        if (!element) continue;
+        element.weight.mentionCount += 1;
+        element.weight.lastAdoptedTurn = this.currentTurn;
+        element.updatedAt = now;
+      }
+      if (receiptId) this.usageReceipts.set(receiptId, {
+        id: receiptId,
+        eventIds: requestedEventIds,
+        elementIds: requestedElementIds,
+        createdAt: now,
+      });
     });
   }
 
@@ -486,6 +720,31 @@ export class StrataGate {
     const event = this.events.find((candidate) => candidate.id === id);
     if (!event) throw new Error(`Unknown event: ${id}`);
     return event;
+  }
+
+  private requireElementProjectionJob(id: string): ElementProjectionJob {
+    const job = this.elementProjectionJobs.get(id);
+    if (!job) throw new Error(`Unknown element projection: ${id}`);
+    return job;
+  }
+
+  private queueElementProjection(sourceEventIds: readonly string[]): ElementProjectionJob | null {
+    const ids = [...new Set(sourceEventIds.filter((id) => this.events.some((event) => event.id === id)))];
+    if (ids.length === 0) return null;
+    const now = this.now().toISOString();
+    const job: ElementProjectionJob = {
+      id: this.elementIdFactory('proj'),
+      sourceEventIds: ids,
+      status: 'pending',
+      attempts: 0,
+      elementIds: [],
+      reason: null,
+      lastError: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.elementProjectionJobs.set(job.id, job);
+    return job;
   }
 
   private pendingBlockMessages(): RawMessage[] {
@@ -592,6 +851,7 @@ export class StrataGate {
       const extracted = result.shouldExtract
         ? result.events.map((event) => this.addEventInMemory({ ...event, sourceBlockId: target.id }))
         : [];
+      if (extracted.length > 0) this.queueElementProjection(extracted.map(({ id }) => id));
       const job = this.extractionJobs.get(target.id);
       if (!job) throw new Error(`Missing extraction job for block: ${target.id}`);
       this.extractionJobs.set(target.id, {
@@ -602,6 +862,19 @@ export class StrataGate {
       });
       return extracted;
     });
+  }
+
+  private async projectEligibleElements(): Promise<ElementCard[] | null> {
+    if (!this.elementProjector) return null;
+    const batch = await this.claimNextElementProjection();
+    if (!batch) return null;
+    try {
+      const result = await this.elementProjector(batch);
+      return await this.completeElementProjection(batch.jobId, result);
+    } catch (error) {
+      await this.failElementProjection(batch.jobId, error);
+      throw error;
+    }
   }
 
   private async commitMutation<T>(mutation: () => T | Promise<T>): Promise<T> {
@@ -640,17 +913,20 @@ export class StrataGate {
   }
 
   private restoreSnapshot(snapshot: StrataGateSnapshot): void {
-    assertValidSnapshot(snapshot);
-    if (snapshot.blockTurnSize !== this.blockTurnSize) {
-      throw new Error(`Snapshot blockTurnSize ${snapshot.blockTurnSize} does not match ${this.blockTurnSize}`);
+    const normalized = normalizeSnapshot(snapshot);
+    if (normalized.blockTurnSize !== this.blockTurnSize) {
+      throw new Error(`Snapshot blockTurnSize ${normalized.blockTurnSize} does not match ${this.blockTurnSize}`);
     }
-    const copy = cloneSnapshot(snapshot);
+    const copy = cloneSnapshot(normalized);
     this.currentTurn = copy.currentTurn;
     this.openTail.splice(0, this.openTail.length, ...copy.openTail);
     this.blocks.splice(0, this.blocks.length, ...copy.blocks);
     this.events.splice(0, this.events.length, ...copy.events);
+    this.elements.splice(0, this.elements.length, ...copy.elements);
     this.extractionJobs.clear();
     for (const job of copy.extractionJobs) this.extractionJobs.set(job.blockId, job);
+    this.elementProjectionJobs.clear();
+    for (const job of copy.elementProjectionJobs) this.elementProjectionJobs.set(job.id, job);
     this.usageReceipts.clear();
     for (const receipt of copy.usageReceipts) this.usageReceipts.set(receipt.id, receipt);
     this.validateReferences();
@@ -684,6 +960,34 @@ export class StrataGate {
     }
     for (const job of this.extractionJobs.values()) {
       if (!blockIds.has(job.blockId)) throw new Error(`Unknown extraction job block in snapshot: ${job.blockId}`);
+    }
+    const elementIds = new Set<string>();
+    for (const element of this.elements) {
+      if (elementIds.has(element.id)) throw new Error(`Duplicate element ID in snapshot: ${element.id}`);
+      elementIds.add(element.id);
+      for (const eventId of element.sourceEventIds) {
+        if (!eventIds.has(eventId)) throw new Error(`Element ${element.id} references unknown event ${eventId}`);
+      }
+      const sourceMessageIds = new Set(element.sourceEventIds.flatMap((eventId) =>
+        this.events.find((event) => event.id === eventId)?.sourceMessageIds ?? []));
+      for (const messageId of element.sourceMessageIds) {
+        if (!sourceMessageIds.has(messageId)) {
+          throw new Error(`Element ${element.id} references message ${messageId} outside its source events`);
+        }
+      }
+      for (const fact of element.facts) {
+        for (const eventId of fact.sourceEventIds) {
+          if (!eventIds.has(eventId)) throw new Error(`Element fact ${fact.id} references unknown event ${eventId}`);
+        }
+      }
+    }
+    for (const job of this.elementProjectionJobs.values()) {
+      for (const eventId of job.sourceEventIds) {
+        if (!eventIds.has(eventId)) throw new Error(`Element projection ${job.id} references unknown event ${eventId}`);
+      }
+      for (const elementId of job.elementIds) {
+        if (!elementIds.has(elementId)) throw new Error(`Element projection ${job.id} references unknown element ${elementId}`);
+      }
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,15 +126,94 @@ export interface ExtractionResult {
 
 export type EventExtractor = (context: ExtractionContext) => Promise<ExtractionResult>;
 
+export type MemoryElementType = 'person' | 'project' | 'organization' | 'tool' | 'place';
+export type ElementFactMode = 'state' | 'set' | 'relation';
+export type ElementFactStatus = 'active' | 'superseded' | 'disputed';
+export type ElementProjectionOperation = 'set_state' | 'add_set_item' | 'set_relation';
+
+export interface ElementFact {
+  id: string;
+  key: string;
+  mode: ElementFactMode;
+  value: string | string[];
+  validFrom?: string;
+  validTo?: string;
+  sourceEventIds: string[];
+  confidence?: number;
+  status: ElementFactStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ElementCard {
+  id: string;
+  name: string;
+  type: MemoryElementType;
+  aliases: string[];
+  currentState: string;
+  facts: ElementFact[];
+  sourceEventIds: string[];
+  sourceMessageIds: string[];
+  weight: MemoryWeight;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ElementProjectionChange {
+  element: {
+    name: string;
+    type: MemoryElementType;
+    aliases?: string[];
+  };
+  operation: ElementProjectionOperation;
+  key: string;
+  mode: ElementFactMode;
+  value: string | string[];
+  validFrom?: string;
+  validTo?: string;
+  sourceEventIds: string[];
+  confidence?: number;
+}
+
+export interface ElementProjectionResult {
+  reason: string;
+  changes: ElementProjectionChange[];
+}
+
+export interface ElementProjectionContext {
+  jobId: string;
+  events: EventCard[];
+  existingElements: ElementCard[];
+}
+
+export type ElementProjector = (context: ElementProjectionContext) => Promise<ElementProjectionResult>;
+
 export interface SearchOptions {
   limit?: number;
-  temporalIntent?: boolean;
+  temporalIntent?: boolean | 'first' | 'latest';
   participants?: string[];
   eventType?: string;
+  happenedFrom?: string;
+  happenedTo?: string;
 }
 
 export interface EventSearchResult {
   event: EventCard;
+  score: number;
+}
+
+export interface ElementSearchOptions {
+  limit?: number;
+  name?: string;
+  type?: MemoryElementType;
+}
+
+export interface ElementSearchResult {
+  id: string;
+  elementId: string;
+  name: string;
+  type: MemoryElementType;
+  fact: ElementFact;
   score: number;
 }
 
@@ -148,4 +227,5 @@ export interface RawSearchHit {
 export interface AppendTurnResult {
   sealedBlock: MemoryBlock | null;
   extractedEvents: EventCard[];
+  projectedElements: ElementCard[];
 }

--- a/tests/elements.test.ts
+++ b/tests/elements.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import {
+  StrataGate,
+  type BlockSummarizer,
+  type ElementProjector,
+  type EventExtractor,
+} from '../src/index.js';
+
+function ids(): (prefix: 'msg' | 'blk' | 'evt') => string {
+  let value = 0;
+  return (prefix) => `${prefix}_${++value}`;
+}
+
+function elementIds(): (prefix: 'elem' | 'fact' | 'proj') => string {
+  let value = 0;
+  return (prefix) => `${prefix}_${++value}`;
+}
+
+const summarizer: BlockSummarizer = async (messages) => ({
+  l0Title: messages[0]?.content ?? 'block',
+  l0Tags: ['project'],
+  l1Summary: messages.map(({ content }) => content).join(' '),
+  l2Keypoints: messages.map(({ content }) => content),
+  shouldExtract: true,
+});
+
+const extractor: EventExtractor = async ({ target }) => ({
+  shouldExtract: true,
+  reason: 'project state changed',
+  events: [{
+    title: 'Database decision',
+    summary: target.l5Raw[0]?.content ?? 'unknown',
+    sourceMessageIds: [target.l5Raw[0]?.id ?? 'missing'],
+    sourceBlockId: target.id,
+    temporal: {
+      happenedStart: target.l5Raw[0]?.createdAt ?? target.createdAt,
+      participants: ['StrataGate'],
+      eventType: 'decision',
+    },
+  }],
+});
+
+const projector: ElementProjector = async ({ events }) => ({
+  reason: 'materialize the project database state',
+  changes: events.map((event) => ({
+    element: { name: 'StrataGate', type: 'project', aliases: ['SG'] },
+    operation: 'set_state',
+    key: 'database',
+    mode: 'state',
+    value: event.summary,
+    validFrom: event.temporal.happenedStart ?? event.createdAt,
+    sourceEventIds: [event.id],
+    confidence: 0.95,
+  })),
+});
+
+describe('element projection and retrieval', () => {
+  it('projects elements independently, preserves event history, and exposes time views', async () => {
+    const memory = new StrataGate({
+      blockTurnSize: 1,
+      summarizer,
+      extractor,
+      elementProjector: projector,
+      idFactory: ids(),
+      elementIdFactory: elementIds(),
+    });
+    await memory.appendTurn({
+      user: 'The project database is SQLite.',
+      assistant: 'Recorded.',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const second = await memory.appendTurn({
+      user: 'The project database is PostgreSQL.',
+      assistant: 'Updated.',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    });
+    expect(second.projectedElements).toHaveLength(1);
+    const immutableFirstEvent = structuredClone(memory.listEvents()[0]);
+
+    await memory.appendTurn({
+      user: 'Confirm the current database.',
+      assistant: 'Checking.',
+      createdAt: '2026-03-01T00:00:00.000Z',
+    });
+
+    expect(memory.listEvents()[0]).toEqual(immutableFirstEvent);
+    const element = memory.listElements()[0];
+    expect(element?.currentState).toContain('PostgreSQL');
+    expect(element?.facts.map(({ status }) => status)).toEqual(['superseded', 'active']);
+    if (!element) return;
+    expect(memory.expandElement(element.id, '2026-01-15T00:00:00.000Z').currentState).toContain('SQLite');
+    expect(memory.expandElement(element.id, '2026-02-15T00:00:00.000Z').currentState).toContain('PostgreSQL');
+  });
+
+  it('retrieves fact-level element evidence with BM25 plus structured rankings', async () => {
+    const memory = new StrataGate({
+      blockTurnSize: 1,
+      summarizer,
+      extractor,
+      elementProjector: projector,
+      idFactory: ids(),
+      elementIdFactory: elementIds(),
+    });
+    await memory.appendTurn({ user: 'The project database is SQLite.', assistant: 'Recorded.' });
+    await memory.appendTurn({ user: 'Continue.', assistant: 'Okay.' });
+
+    expect((await memory.searchElements('SQLite database'))[0]).toMatchObject({
+      name: 'StrataGate',
+      type: 'project',
+    });
+    expect(await memory.searchElements('watermelon')).toEqual([]);
+    expect(await memory.searchElements('', { type: 'project' })).toHaveLength(1);
+    expect(await memory.searchEvents('watermelon')).toEqual([]);
+    expect(await memory.searchEvents('', { participants: ['StrataGate'] })).toHaveLength(1);
+  });
+
+  it('retries only a failed projection and rejects facts without batch provenance', async () => {
+    const memory = new StrataGate({
+      blockTurnSize: 1,
+      summarizer,
+      idFactory: ids(),
+      elementIdFactory: elementIds(),
+    });
+    await memory.appendTurn({ user: 'source', assistant: 'stored' });
+    const block = memory.listBlocks()[0];
+    expect(block).toBeDefined();
+    if (!block) return;
+    const event = await memory.addEvent({
+      title: 'Source event',
+      summary: 'Auditable source',
+      sourceBlockId: block.id,
+      sourceMessageIds: [block.l5Raw[0]?.id ?? 'missing'],
+    });
+    const firstClaim = await memory.claimNextElementProjection();
+    expect(firstClaim?.events.map(({ id }) => id)).toEqual([event.id]);
+    if (!firstClaim) return;
+    await memory.failElementProjection(firstClaim.jobId, new Error('temporary failure'));
+    const retry = await memory.claimNextElementProjection();
+    expect(retry?.jobId).toBe(firstClaim.jobId);
+    expect(memory.listElementProjectionJobs()[0]?.attempts).toBe(2);
+    if (!retry) return;
+    const projected = await memory.completeElementProjection(retry.jobId, {
+      reason: 'invalid provenance is ignored',
+      changes: [{
+        element: { name: 'StrataGate', type: 'project' },
+        operation: 'set_state',
+        key: 'database',
+        mode: 'state',
+        value: 'must not land',
+        sourceEventIds: [event.id, 'event_outside_batch'],
+      }],
+    });
+    expect(projected).toEqual([]);
+    expect(memory.listEvents()).toHaveLength(1);
+    expect(memory.listElements()).toHaveLength(0);
+  });
+});

--- a/tests/persistence.test.ts
+++ b/tests/persistence.test.ts
@@ -52,17 +52,17 @@ const extractor: EventExtractor = async ({ target }) => ({
 });
 
 describe('SQLite persistence', () => {
-  it('creates schema version one and rejects a newer database schema', async () => {
+  it('creates schema version two and rejects a newer database schema', async () => {
     const initializedFilename = await databasePath();
     const initialized = new SqliteStorage({ filename: initializedFilename });
     await initialized.close();
     const initializedDatabase = new Database(initializedFilename, { readonly: true });
-    expect(initializedDatabase.pragma('user_version', { simple: true })).toBe(1);
+    expect(initializedDatabase.pragma('user_version', { simple: true })).toBe(2);
     initializedDatabase.close();
 
     const newerFilename = await databasePath();
     const newerDatabase = new Database(newerFilename);
-    newerDatabase.pragma('user_version = 2');
+    newerDatabase.pragma('user_version = 3');
     newerDatabase.close();
     expect(() => new SqliteStorage({ filename: newerFilename })).toThrow('newer than supported');
   });
@@ -228,7 +228,7 @@ describe('SQLite persistence', () => {
       await restored.recordMemoryUse([restoredEvent.id], { receiptId: 'answer:42' });
       expect(restoredEvent.weight.mentionCount).toBe(2);
       await expect(restored.recordMemoryUse([], { receiptId: 'answer:42' }))
-        .rejects.toThrow('different event IDs');
+        .rejects.toThrow('different memory IDs');
     }
     await restored.close();
   });
@@ -256,5 +256,95 @@ describe('SQLite persistence', () => {
     expect(stale.listOpenTail()).toHaveLength(0);
     await first.close();
     await stale.close();
+  });
+
+  it('migrates a schema-v1 database in place without losing its namespace', async () => {
+    const filename = await databasePath();
+    const legacy = new Database(filename);
+    legacy.exec(`
+      CREATE TABLE memory_spaces (
+        namespace TEXT PRIMARY KEY,
+        schema_version INTEGER NOT NULL,
+        revision INTEGER NOT NULL,
+        current_turn INTEGER NOT NULL,
+        block_turn_size INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT;
+      CREATE TABLE usage_receipts (
+        namespace TEXT NOT NULL,
+        receipt_id TEXT NOT NULL,
+        event_ids_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (namespace, receipt_id),
+        FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE
+      ) STRICT;
+      INSERT INTO memory_spaces VALUES ('legacy:user', 1, 7, 0, 12, '2026-01-01', '2026-01-01');
+      PRAGMA user_version = 1;
+    `);
+    legacy.close();
+
+    const storage = new SqliteStorage({ filename });
+    const loaded = await storage.load('legacy:user');
+    expect(loaded?.revision).toBe(7);
+    expect(loaded?.snapshot).toMatchObject({ schemaVersion: 2, elements: [], elementProjectionJobs: [] });
+    await storage.close();
+
+    const migrated = new Database(filename, { readonly: true });
+    expect(migrated.pragma('user_version', { simple: true })).toBe(2);
+    expect((migrated.pragma('table_info(usage_receipts)') as Array<{ name: string }>)
+      .map(({ name }) => name)).toContain('element_ids_json');
+    expect(migrated.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'elements'")
+      .pluck().get()).toBe('elements');
+    migrated.close();
+  });
+
+  it('persists projected elements and idempotent element-use receipts across restarts', async () => {
+    const filename = await databasePath();
+    const storage = new SqliteStorage({ filename });
+    const elementIdFactory = (() => {
+      let value = 0;
+      return (prefix: 'elem' | 'fact' | 'proj') => `${prefix}_${++value}`;
+    })();
+    const first = await StrataGate.open({
+      storage,
+      namespace: 'project:elements',
+      blockTurnSize: 1,
+      summarizer,
+      extractor,
+      idFactory: ids(),
+      elementIdFactory,
+      elementProjector: async ({ events }) => ({
+        reason: 'project current state',
+        changes: [{
+          element: { name: 'StrataGate', type: 'project' },
+          operation: 'set_state',
+          key: 'storage',
+          mode: 'state',
+          value: 'SQLite',
+          sourceEventIds: [events[0]?.id ?? 'missing'],
+        }],
+      }),
+      now: fixedNow,
+    });
+    await first.appendTurn({ user: 'Use SQLite.', assistant: 'Recorded.' });
+    await first.appendTurn({ user: 'Continue.', assistant: 'Okay.' });
+    const element = first.listElements()[0];
+    expect(element?.currentState).toContain('SQLite');
+    if (!element) return;
+    await first.recordMemoryUse({ elementIds: [element.id] }, { receiptId: 'answer:element:1' });
+    await first.recordMemoryUse({ elementIds: [element.id] }, { receiptId: 'answer:element:1' });
+    expect(element.weight.mentionCount).toBe(2);
+    await first.close();
+
+    const restoredStorage = new SqliteStorage({ filename });
+    const restored = await StrataGate.open({ storage: restoredStorage, namespace: 'project:elements' });
+    expect(restored.listElements()[0]).toMatchObject({
+      name: 'StrataGate',
+      currentState: 'storage: SQLite',
+      weight: { mentionCount: 2 },
+    });
+    expect(restored.listElementProjectionJobs()[0]?.status).toBe('completed');
+    await restored.close();
   });
 });

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { bm25Rank, rrfRank, searchTokens, weightedSearchTokens } from '../src/index.js';
+
+describe('auditable hybrid ranking', () => {
+  const documents = [
+    { id: 'alpha', title: 'PostgreSQL migration', body: 'Move the project database to PostgreSQL.' },
+    { id: 'beta', title: 'Design review', body: 'Review the application layout.' },
+  ];
+
+  it('uses BM25 lexical ranking and returns no candidates on a real zero match', () => {
+    const ranked = bm25Rank(documents, 'PostgreSQL database', (item) =>
+      weightedSearchTokens([[item.title, 3], [item.body, 1]]));
+    expect(ranked.map(({ item }) => item.id)).toEqual(['alpha']);
+    expect(bm25Rank(documents, 'watermelon', (item) => searchTokens(`${item.title} ${item.body}`))).toEqual([]);
+  });
+
+  it('fuses independent rankings without hiding their deterministic order', () => {
+    const fused = rrfRank([
+      [documents[0]!, documents[1]!],
+      [documents[1]!, documents[0]!],
+    ]);
+    expect(fused.map(({ item }) => item.id)).toEqual(['alpha', 'beta']);
+    expect(fused[0]?.score).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What changed

- add event-sourced element cards for people, projects, organizations, tools, and places
- persist independently retryable element-projection jobs and validate every proposed fact against the claimed event batch
- retain superseded state facts with validity intervals and expose historical views through `expandElement(id, at)`
- add deterministic BM25 lexical ranking plus structured rankings and reciprocal-rank fusion for event and fact-level element search
- add SQLite schema v2 with normalized element/fact/provenance tables and an in-place v1 migration
- extend evidence-gate strategies, usage receipts, the example, and bilingual architecture documentation

## Why

The round-eight documentation and evaluation results described element cards and BM25/RRF retrieval, but the public StrataGate implementation still exposed only the earlier event-centric path. This PR makes the public code match the evaluated architecture without copying MemoryLab benchmark controllers or run artifacts into the library.

## Impact

Applications can supply an `elementProjector` callback or drive the claim/complete/fail projection API themselves. Existing event-only callers remain supported. SQLite databases created with schema v1 are migrated transactionally on open.

## Validation

- `npm run check`
- `npm test` (18 tests passed)
- `npm run build`
- `npm pack --dry-run`
- `git diff --check`
