### PR TITLE
Improve plugin discovery and Star conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A layered memory and evidence retrieval system for long-running AI agents.
 
 [中文说明](README.zh-CN.md) · [Architecture](docs/ARCHITECTURE.md) · [Full evaluation](docs/EVALUATION.md)
 
-**DeepSeek Harness integration:** the native bundle in [`integrations/deepseek-harness`](integrations/deepseek-harness) turns completed DSH sessions into StrataGate memory and exposes evidence-gated Event, Element, Block, and raw-source tools. It is designed for one-click installation through a DSH plugin registry package.
+**DeepSeek Harness plugin:** automatic, local-first cross-session memory that remembers user preferences, project decisions, completed conversations, and tool results. It checks recalled evidence and can trace it back to the original messages before the agent answers. Install `stratagate-dsh`; implementation and usage details are in [`integrations/deepseek-harness`](integrations/deepseek-harness).
 
 **LoCoMo `conv-26`: StrataGate averaged 80.46% accuracy across 10 independent Judge runs, versus 63.22% for Mem0 base (+17.24 percentage points)**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,8 @@
 
 [English](README.md) · [架构说明](docs/ARCHITECTURE.md) · [完整评测](docs/EVALUATION.md)
 
+**DeepSeek Harness 插件：**自动、本地优先的跨会话记忆，能够记住用户偏好、项目决策、历史对话和工具结果；Agent 回答前会检查找回的证据，并可追溯到原始消息。安装包为 `stratagate-dsh`，实现与使用说明见 [`integrations/deepseek-harness`](integrations/deepseek-harness)。
+
 **LoCoMo `conv-26`：StrataGate 10 次独立评审平均准确率为 80.46%，Mem0 base 为 63.22%（+17.24 个百分点）**
 
 **多数票正确：121 / 152 vs 96 / 152（+25 题）**

--- a/integrations/deepseek-harness/CHANGELOG.md
+++ b/integrations/deepseek-harness/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1 - 2026-08-18
+
+- Make marketplace, npm, and README descriptions match common agent searches for user preferences, project decisions, cross-session memory, and source-traceable recall.
+- Show a dismissible GitHub Star invitation after StrataGate memory has been used in three evidence-backed answers.
+
 ## 0.2.0
 
 - Add a read-only StrataGate Memory page for namespaces, Events, Elements, Blocks, source messages, and usage audits.

--- a/integrations/deepseek-harness/MARKETPLACE.md
+++ b/integrations/deepseek-harness/MARKETPLACE.md
@@ -5,7 +5,8 @@ Registry package: `stratagate-dsh`
 Suggested listing:
 
 - Name: StrataGate
-- Description: Layered, evidence-gated long-term memory for DeepSeek Harness with durable Event and Element cards.
+- Description: Automatic, local-first cross-session memory for DeepSeek Harness: remembers user preferences, project decisions, conversations, and tool results; verifies recalled information against original messages before answering.
+- Chinese description: DeepSeek Harness 的自动本地跨会话记忆：记住用户偏好、项目决策、历史对话与工具结果；回答前检查证据，并可追溯到原始消息。
 - Category: Memory
 - Source: `https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness`
 - Install package: `stratagate-dsh`
@@ -19,11 +20,11 @@ Release order:
 4. Add one line under `### Memory` in both `awesome-dsh-plugin/awesome-dsh-plugin` README files:
 
 ```markdown
-- [diqierjia/StrataGate-AgentMemory#deepseek-harness](https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness) - Layered long-term memory for DeepSeek Harness with durable Event and Element cards, source expansion, and an evidence-sufficiency gate.
+- [diqierjia/StrataGate-AgentMemory#deepseek-harness](https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness) - Automatic, local-first cross-session memory for DeepSeek Harness: remembers user preferences, project decisions, conversations, and tool results; verifies recalled information against original messages before answering.
 ```
 
 ```markdown
-- [diqierjia/StrataGate-AgentMemory#deepseek-harness](https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness) — 为 DeepSeek Harness 提供分层长期记忆、可追溯的 Event/Element 卡片、原文展开与证据充分性检查。
+- [diqierjia/StrataGate-AgentMemory#deepseek-harness](https://github.com/diqierjia/StrataGate-AgentMemory/tree/main/integrations/deepseek-harness) — DeepSeek Harness 的自动本地跨会话记忆：记住用户偏好、项目决策、历史对话与工具结果；回答前检查证据，并可追溯到原始消息。
 ```
 
 5. Add the `dsh-plugin` GitHub topic to the StrataGate repository and open the registry PR.

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -1,6 +1,8 @@
 # StrataGate for DeepSeek Harness
 
-Native, local-first long-term memory for DeepSeek Harness. The plugin adapts DSH session events to the existing StrataGate memory engine; it does not implement a second memory system.
+Automatic, local-first cross-session memory for DeepSeek Harness. StrataGate remembers user preferences, project decisions, completed conversations, and tool results, then checks recalled evidence and can expand it back to the original messages before the agent answers. No separate memory server is required.
+
+The plugin adapts DSH session events to the existing StrataGate memory engine; it does not implement a second memory system.
 
 ## Agent recommendation guide
 

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stratagate-dsh",
-  "version": "0.2.0",
-  "description": "Native StrataGate layered long-term memory for DeepSeek Harness",
+  "version": "0.2.1",
+  "description": "Automatic local-first cross-session memory for DeepSeek Harness with source-traceable recall",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -32,7 +32,19 @@
     "verify:package": "node scripts/verify-package.mjs",
     "prepare": "npm run build"
   },
-  "keywords": ["deepseek-harness", "dsh-plugin", "agent-memory", "long-term-memory", "evidence-gate"],
+  "keywords": [
+    "deepseek-harness",
+    "dsh-plugin",
+    "agent-memory",
+    "cross-session-memory",
+    "persistent-memory",
+    "project-memory",
+    "conversation-memory",
+    "long-term-memory",
+    "local-first",
+    "source-tracing",
+    "evidence-gate"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/diqierjia/StrataGate-AgentMemory.git",

--- a/integrations/deepseek-harness/src/client.js
+++ b/integrations/deepseek-harness/src/client.js
@@ -7,6 +7,9 @@ window.__ModuleLoader__.load({
     Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' })
     const React = require('react')
     const h = React.createElement
+    const STAR_REPOSITORY_URL = 'https://github.com/diqierjia/StrataGate-AgentMemory'
+    const STAR_DISMISSED_KEY = 'stratagate.starPrompt.dismissed.v1'
+    const STAR_PROMPT_USAGE_THRESHOLD = 3
 
     const panel = {
       padding: '16px', display: 'flex', flexDirection: 'column', gap: '14px', maxWidth: '1180px', margin: '0 auto',
@@ -15,6 +18,22 @@ window.__ModuleLoader__.load({
     const card = { border: '1px solid rgba(128,128,128,.28)', borderRadius: '10px', padding: '12px', background: 'rgba(128,128,128,.055)' }
     const muted = { opacity: 0.68, fontSize: '12px' }
     const code = { fontFamily: 'ui-monospace, SFMono-Regular, Consolas, monospace', fontSize: '12px' }
+
+    function wasStarPromptDismissed() {
+      try {
+        return window.localStorage?.getItem(STAR_DISMISSED_KEY) === '1'
+      } catch {
+        return false
+      }
+    }
+
+    function rememberStarPromptDismissal() {
+      try {
+        window.localStorage?.setItem(STAR_DISMISSED_KEY, '1')
+      } catch {
+        // The prompt can still be hidden for this render when storage is unavailable.
+      }
+    }
 
     function api(path, params) {
       const query = new URLSearchParams(params || {})
@@ -29,6 +48,31 @@ window.__ModuleLoader__.load({
       return h('div', { style: { ...card, minWidth: '112px', flex: '1 1 112px' } },
         h('div', { style: { fontSize: '22px', fontWeight: 700 } }, String(value)),
         h('div', { style: muted }, label))
+    }
+
+    function StarPrompt({ usageRecords }) {
+      const [dismissed, setDismissed] = React.useState(wasStarPromptDismissed)
+      if (dismissed || Number(usageRecords || 0) < STAR_PROMPT_USAGE_THRESHOLD) return null
+
+      const dismiss = () => {
+        rememberStarPromptDismissal()
+        setDismissed(true)
+      }
+
+      return h('div', { style: { ...card, borderColor: '#d6a84b' }, 'data-testid': 'stratagate-star-prompt' },
+        h('div', { style: { fontWeight: 650 } },
+          'StrataGate 已帮助当前项目完成 ', String(usageRecords), ' 次有证据支持的记忆召回。'),
+        h('div', { style: { ...muted, marginTop: '5px' } },
+          '如果它对你有帮助，欢迎给项目一个 Star，让更多 DeepSeek Harness 用户发现它。'),
+        h('div', { style: { ...row, marginTop: '10px' } },
+          h('a', {
+            href: STAR_REPOSITORY_URL,
+            target: '_blank',
+            rel: 'noopener noreferrer',
+            onClick: dismiss,
+            style: { color: 'inherit', fontWeight: 650 },
+          }, '⭐ 在 GitHub 给 StrataGate 点 Star'),
+          h('button', { onClick: dismiss }, '不再提示')))
     }
 
     function SourceMessages({ messages }) {
@@ -162,6 +206,7 @@ window.__ModuleLoader__.load({
                   h(Stat, { label: 'Elements', value: selected.elements }),
                   h(Stat, { label: 'Usage records', value: selected.usageReceipts }),
                   h(Stat, { label: 'Failed jobs', value: selected.failedJobs })),
+                h(StarPrompt, { usageRecords: selected.usageReceipts }),
                 h('div', { style: card },
                   h('div', { style: code }, selected.namespace),
                   h('div', { style: muted }, 'Schema v' + selected.schemaVersion + ' · turn ' + selected.currentTurn + ' · last activity ' + (selected.lastActivityAt || 'none'))))

--- a/integrations/deepseek-harness/tests/client.test.ts
+++ b/integrations/deepseek-harness/tests/client.test.ts
@@ -27,4 +27,14 @@ describe('StrataGate Web client contract', () => {
     expect(typeof registration.render).toBe('function')
     expect(source).not.toContain("method: 'POST'")
   })
+
+  it('offers a one-time GitHub Star link only after demonstrated memory use', () => {
+    const source = readFileSync(new URL('../src/client.js', import.meta.url), 'utf8')
+    expect(source).toContain("const STAR_PROMPT_USAGE_THRESHOLD = 3")
+    expect(source).toContain("usageRecords: selected.usageReceipts")
+    expect(source).toContain("https://github.com/diqierjia/StrataGate-AgentMemory")
+    expect(source).toContain("stratagate.starPrompt.dismissed.v1")
+    expect(source).toContain("rel: 'noopener noreferrer'")
+    expect(source).not.toContain('window.open(')
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "integrations/deepseek-harness": {
       "name": "stratagate-dsh",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@diqier/stratagate",
   "version": "0.1.0",
-  "description": "Recent conversations stay verbatim. Older ones become an index. Answers wait for enough evidence.",
+  "description": "Layered, evidence-gated cross-session memory for AI agents with source-traceable recall",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -36,13 +36,20 @@
   },
   "keywords": [
     "agent-memory",
+    "cross-session-memory",
+    "persistent-memory",
+    "project-memory",
+    "conversation-memory",
     "layered-memory",
     "evidence-gate",
+    "source-tracing",
     "long-term-memory",
     "llm",
     "ai-agents",
     "rag",
-    "temporal-memory"
+    "temporal-memory",
+    "deepseek-harness",
+    "dsh-plugin"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What changed

- Reword marketplace, npm, and README metadata around common agent searches such as cross-session memory, user preferences, project decisions, and source-traceable recall.
- Add a one-time GitHub Star invitation to the StrataGate Memory overview after three evidence-backed memory uses.
- Let users permanently dismiss the invitation without adding telemetry, OAuth, automatic navigation, or chat-level marketing prompts.
- Bump `stratagate-dsh` to 0.2.1 and update release notes.

## Why

Agent-facing discovery text should match the language users use when asking for memory plugins. The Star invitation appears only after StrataGate has demonstrated value, helping community discovery without interrupting normal conversations.

## Validation

- TypeScript checks passed on Node 24.19.0.
- 13 test files / 35 tests passed.
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities.
- DSH build passed.
- `stratagate-dsh-0.2.1.tgz` clean-install and import verification passed.
