### PR TITLE
Release StrataGate DSH 0.2.16

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,7 +14,7 @@
 
 [English](README.md) · [架构说明](docs/ARCHITECTURE.md) · [完整评测](docs/EVALUATION.md)
 
-**DeepSeek Harness 插件：**自动、本地优先的跨会话记忆，能够记住用户偏好、项目决策、历史对话和工具结果；Agent 回答前会检查找回的证据，并可追溯到原始消息。安装包为 `stratagate-dsh`，实现与使用说明见 [DeepSeek Harness 插件中文文档](integrations/deepseek-harness/README.zh-CN.md)。
+**DeepSeek Harness 插件：**自动、本地优先的跨会话记忆，能够记住用户偏好、项目决策、历史对话和工具结果；Agent 回答前会检查找回的证据，并可追溯到原始消息。安装包为 `stratagate-dsh`，实现与使用说明见 [DeepSeek Harness 插件中文文档](integrations/deepseek-harness/docs/README.zh-CN.md)。
 
 **LoCoMo `conv-26`：StrataGate 10 次独立评审平均准确率为 80.46%，Mem0 base 为 63.22%（+17.24 个百分点）**
 
@@ -375,7 +375,7 @@ DeepSeek Harness 用户可以直接安装预构建插件：
 dsh plugin --profile web add stratagate-dsh
 ```
 
-DSH 适配层的行为、工具、配置和失败恢复方式见 [DeepSeek Harness 插件中文文档](integrations/deepseek-harness/README.zh-CN.md)。
+DSH 适配层的行为、工具、配置和失败恢复方式见 [DeepSeek Harness 插件中文文档](integrations/deepseek-harness/docs/README.zh-CN.md)。
 
 ## 许可证
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,8 @@ The data flow from blocks to event cards and from events to element cards is one
 
 A completed user/assistant pair is one turn. The default block boundary is 12 completed turns. Messages that have not reached the boundary remain in the open tail and are not condensed or extracted.
 
+Hosts may attach a `threadId` to each turn. Open tails, Block boundaries, neighboring extraction context, turn ranges, and decay pointers are then isolated by thread. Persisted Blocks remain available as provenance for long-term cards, while host integrations must inject only the active thread's short-term Block context.
+
 When the boundary is reached:
 
 1. L5 stores the raw messages and tool traces.
@@ -224,4 +226,4 @@ The adapter preserves these invariants:
 - forget is reversible unless an application explicitly implements irreversible deletion;
 - usage receipts are idempotent for one answer turn through a unique `receiptId`.
 
-SQLite schema v4 includes normalized element, fact, provenance, projection-job, ingestion-receipt, and usage-audit data. Usage receipts can carry the DSH session, turn, retrieval batch, assessment, and exact evidence references that led to an answer. Opening a schema-v1, v2, or v3 database migrates it in one transaction and preserves existing namespaces, blocks, events, jobs, and receipts. SQLite uses WAL, foreign keys, and per-namespace optimistic concurrency. It does not provide encryption at rest. Search still uses the reference in-memory ranking after hydration, so enabling persistence does not silently change retrieval semantics. Database-native lexical/vector indexes and a Postgres implementation remain separate future work.
+SQLite schema v5 includes normalized element, fact, provenance, projection-job, ingestion-receipt, usage-audit, and optional thread ownership for messages and Blocks. Usage receipts can carry the DSH session, turn, retrieval batch, assessment, and exact evidence references that led to an answer. Opening a schema-v1 through v4 database migrates it in one transaction and preserves existing namespaces, blocks, events, jobs, and receipts. Pre-v5 Blocks retain no inferred thread ownership, so they remain archival provenance without being attached to a new session. SQLite uses WAL, foreign keys, and per-namespace optimistic concurrency. It does not provide encryption at rest. Search still uses the reference in-memory ranking after hydration, so enabling persistence does not silently change retrieval semantics. Database-native lexical/vector indexes and a Postgres implementation remain separate future work.

--- a/integrations/deepseek-harness/CHANGELOG.md
+++ b/integrations/deepseek-harness/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.16 - 2026-08-21
+
+- Isolate open tails, Block sealing, decay, and automatic Block context by DSH session while keeping Events and Elements project-scoped for cross-session recall.
+- Migrate SQLite storage to schema v5 with optional thread ownership on raw messages and Blocks; pre-v5 Blocks remain unowned archival provenance instead of being injected into new sessions.
+
 ## 0.2.15 - 2026-08-21
 
 - Disable reasoning for internal structured memory workers because the current DSH adapters do not map `tool_choice` to the provider request.

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -70,9 +70,9 @@ Removing the plugin does not delete that database.
 - Subagent turns are not ingested by default; subagents in the same project can still read project memory.
 - Each DSH turn has a durable ingestion receipt, so replay or retry cannot store it twice.
 - StrataGate performs the existing Block summarization, Event extraction, Element projection, search, Evidence Gate, and use-only reinforcement.
-- Before every main-model call, the plugin injects the complete open tail, each sealed Block at its current decay-pointer level, and up to four activated Events plus four active Element facts.
+- Before every main-model call, the plugin injects only the current session's open tail and sealed Blocks, plus up to four project-scoped activated Events and four active Element facts. Blocks remain persisted as source evidence, but they are never automatically carried into another session.
 
-Activated memory uses the current human message plus the latest two open-tail turns as its query. Existing BM25 search remains the lexical relevance gate; pinned and safety memory are the only exceptions. Existing memory weights provide a second ranking, and RRF fuses the relevance and weight rankings. The activated section has a fixed budget of about 900 tokens, so it does not grow with the database.
+Activated memory uses the current human message plus the latest two open-tail turns from the current session as its query. Existing BM25 search remains the lexical relevance gate; pinned and safety memory are the only exceptions. Existing memory weights provide a second ranking, and RRF fuses the relevance and weight rankings. The activated section has a fixed budget of about 900 tokens, so it does not grow with the database.
 
 Automatic context contains only compact Event and fact fields and is explicitly marked as historical background rather than instructions. Building it never calls `recordMemoryUse`, increments `mentionCount`, or changes `lastAdoptedTurn`. The existing `memory_*` tools remain available for deeper, evidence-gated retrieval and are the only path to adoption reinforcement.
 

--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -1,6 +1,6 @@
 # StrataGate for DeepSeek Harness
 
-[English](README.md) · [简体中文](README.zh-CN.md)
+[English](README.md) · [简体中文](docs/README.zh-CN.md)
 
 Automatic, local-first cross-session memory for DeepSeek Harness. StrataGate remembers user preferences, project decisions, completed conversations, and tool results, then checks recalled evidence and can expand it back to the original messages before the agent answers. No separate memory server is required.
 

--- a/integrations/deepseek-harness/README.zh-CN.md
+++ b/integrations/deepseek-harness/README.zh-CN.md
@@ -70,9 +70,9 @@ DSH_HOME/stratagate/memory.db
 - 默认不保存子 Agent 的对话轮次；同一项目中的子 Agent 仍然可以读取项目记忆。
 - 每个 DSH 对话轮次都有持久化的写入回执，因此重放或重试不会导致重复保存。
 - StrataGate 会执行现有的 Block 摘要、Event 提取、Element 投影、搜索、Evidence Gate（证据门控）以及仅在使用后触发的强化。
-- 每次主模型调用前，插件都会注入完整 open tail、每个已封 Block 当前衰减指针所指向的层级，以及最多 4 条激活 Event 和 4 条 active ElementFact。
+- 每次主模型调用前，插件只会注入当前会话的 open tail 与已封 Block，并额外注入最多 4 条项目级激活 Event 和 4 条 active ElementFact。Block 仍会作为来源证据持久化，但绝不会自动带入其他会话。
 
-激活查询由当前人类消息和 open tail 最近两个 turn 组成。现有 BM25 搜索继续作为词面相关性门槛，只有 pinned 和 safety 记忆可以例外进入候选；现有记忆权重提供第二路排序，再由 RRF 融合相关性与权重排序。激活区固定使用约 900 tokens 的预算，不会随数据库增大而增长。
+激活查询由当前人类消息和当前会话 open tail 的最近两个 turn 组成。现有 BM25 搜索继续作为词面相关性门槛，只有 pinned 和 safety 记忆可以例外进入候选；现有记忆权重提供第二路排序，再由 RRF 融合相关性与权重排序。激活区固定使用约 900 tokens 的预算，不会随数据库增大而增长。
 
 自动上下文只包含精简的 Event 与 fact 字段，并明确标注为历史背景而非指令。构建自动上下文不会调用 `recordMemoryUse`，不会增加 `mentionCount`，也不会更新 `lastAdoptedTurn`。现有 `memory_*` 工具仍用于更深入、经过 Evidence Gate 的主动检索，也是触发采用强化的唯一入口。
 

--- a/integrations/deepseek-harness/docs/README.zh-CN.md
+++ b/integrations/deepseek-harness/docs/README.zh-CN.md
@@ -1,6 +1,6 @@
 # StrataGate for DeepSeek Harness
 
-[English](README.md) · [简体中文](README.zh-CN.md)
+[English](../README.md) · [简体中文](README.zh-CN.md)
 
 面向 DeepSeek Harness 的自动、本地优先跨会话记忆。StrataGate 能够记住用户偏好、项目决策、已完成的对话和工具结果；Agent 回答前会检查找回的证据，并可将其展开追溯到原始消息。无需单独部署记忆服务器。
 

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stratagate-dsh",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Automatic local-first cross-session memory for DeepSeek Harness with source-traceable recall",
   "type": "module",
   "main": "./dist/index.js",

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -17,7 +17,7 @@
     "./cordis.patch.yml": "./cordis.patch.yml",
     "./package.json": "./package.json"
   },
-  "files": ["dist", "cordis.patch.yml", "README.md", "CHANGELOG.md", "LICENSE"],
+  "files": ["dist", "cordis.patch.yml", "README.md", "docs/README.zh-CN.md", "CHANGELOG.md", "LICENSE"],
   "dsh": {
     "bundle": { "patch": "./cordis.patch.yml" },
     "client": {
@@ -33,6 +33,13 @@
     "prepare": "npm run build"
   },
   "keywords": [
+    "memory",
+    "dsh",
+    "deepseek",
+    "plugin",
+    "agent",
+    "cross-session",
+    "evidence",
     "deepseek-harness",
     "dsh-plugin",
     "agent-memory",
@@ -42,6 +49,9 @@
     "conversation-memory",
     "long-term-memory",
     "local-first",
+    "time-decay",
+    "usage-reinforcement",
+    "source-traceability",
     "source-tracing",
     "evidence-gate"
   ],

--- a/integrations/deepseek-harness/scripts/verify-package.mjs
+++ b/integrations/deepseek-harness/scripts/verify-package.mjs
@@ -38,6 +38,7 @@ try {
     'package.json',
     'cordis.patch.yml',
     'README.md',
+    'docs/README.zh-CN.md',
     'CHANGELOG.md',
     'LICENSE',
     'dist/index.js',
@@ -46,6 +47,7 @@ try {
     'dist/client.d.ts',
   ]
   for (const path of required) assert(files.has(path), `Packed artifact is missing ${path}`)
+  assert(!files.has('README.zh-CN.md'), 'Localized README must not compete with README.md at the package root')
   for (const path of files) {
     assert(!/^(src|tests|scripts|benchmarks)\//.test(path), `Development file leaked into package: ${path}`)
     assert(!/\.(?:db|sqlite3?|pem|key)$/i.test(path), `Sensitive/runtime file leaked into package: ${path}`)

--- a/integrations/deepseek-harness/src/fold.ts
+++ b/integrations/deepseek-harness/src/fold.ts
@@ -111,6 +111,7 @@ export class TurnFolder {
         return {
           user: pending.user.join('\n\n'),
           assistant: pending.assistant.join('\n\n') || reasonLabel(event.data.reason),
+          threadId: sessionId,
           assistantToolCalls: [...pending.tools.values()],
           createdAt: toUtc8Iso(event.time),
           receiptId: `dsh:${sessionId}:turn:${event.data.turn}`,

--- a/integrations/deepseek-harness/src/runtime.ts
+++ b/integrations/deepseek-harness/src/runtime.ts
@@ -115,7 +115,7 @@ export class StrataGateRuntime {
 
   async blocks(session: Session): Promise<unknown> {
     await this.flush()
-    const results = (await this.space(session)).getBlockContext()
+    const results = (await this.space(session)).getBlockContext(String(session.id))
     return this.batch(session, results.map((result) => ({
       ref: `block:${result.id}:level:${result.level}`,
       target: { eventIds: [], elementIds: [] },
@@ -246,7 +246,8 @@ export class StrataGateRuntime {
   async buildAutoContext(session: Session): Promise<string> {
     await this.flush()
     const memory = await this.space(session)
-    const openTail = memory.listOpenTail()
+    const threadId = String(session.id)
+    const openTail = memory.listOpenTail(threadId)
     const activationQuery = [currentUserMessage(session), renderMessages(recentTurns(openTail, 2))]
       .filter(Boolean)
       .join('\n\n')
@@ -265,7 +266,7 @@ export class StrataGateRuntime {
       openTail.length > 0 ? renderMessages(openTail) : '(open tail is empty)',
       '',
       '[Decayed memory blocks]',
-      renderBlocks(memory.getBlockContext()),
+      renderBlocks(memory.getBlockContext(threadId)),
       '',
       renderActivatedMemory(events, elements),
     ].join('\n')

--- a/integrations/deepseek-harness/tests/fold.test.ts
+++ b/integrations/deepseek-harness/tests/fold.test.ts
@@ -60,6 +60,7 @@ describe('DSH turn folding', () => {
     expect(folded).toMatchObject({
       user: 'Fix login',
       assistant: 'I will inspect it.\n\nFixed and tested.',
+      threadId: 'session-1',
       receiptId: 'dsh:session-1:turn:7',
       assistantToolCalls: [{ name: 'read_file', arguments: { path: 'src/login.ts' }, result: 'file contents' }],
     })

--- a/integrations/deepseek-harness/tests/runtime.test.ts
+++ b/integrations/deepseek-harness/tests/runtime.test.ts
@@ -68,8 +68,8 @@ describe('DSH runtime ingestion', () => {
     try {
       const memory = await (runtime as unknown as { space: (session: Session) => Promise<StrataGate> })
         .space(activeSession)
-      await memory.appendTurn({ user: 'Initial setup.', assistant: 'Ready.' })
-      await memory.appendTurn({ user: 'Seal this block.', assistant: 'Sealed.' })
+      await memory.appendTurn({ user: 'Initial setup.', assistant: 'Ready.', threadId: String(activeSession.id) })
+      await memory.appendTurn({ user: 'Seal this block.', assistant: 'Sealed.', threadId: String(activeSession.id) })
       const block = memory.listBlocks()[0]
       expect(block).toBeDefined()
 
@@ -120,7 +120,11 @@ describe('DSH runtime ingestion', () => {
         sourceBlockId: block!.id,
         criticality: 'safety',
       })
-      await memory.appendTurn({ user: 'We chose pnpm earlier.', assistant: 'I will keep that in mind.' })
+      await memory.appendTurn({
+        user: 'We chose pnpm earlier.',
+        assistant: 'I will keep that in mind.',
+        threadId: String(activeSession.id),
+      })
 
       const before = new Map(memory.listEvents().map((event) => [
         event.id,
@@ -150,6 +154,68 @@ describe('DSH runtime ingestion', () => {
       for (const event of memory.listEvents()) {
         expect([event.weight.mentionCount, event.weight.lastAdoptedTurn]).toEqual(before.get(event.id))
       }
+    } finally {
+      await runtime.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps short-term blocks session-local while activating project long-term memory', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'stratagate-dsh-session-scope-'))
+    const database = join(directory, 'memory.db')
+    const sessionA = {
+      ...session,
+      id: 'session-a',
+      header: { ...session.header, id: 'session-a' },
+      events: [],
+      deriveMessages: () => [],
+    } as unknown as Session
+    const sessionB = {
+      ...session,
+      id: 'session-b',
+      header: { ...session.header, id: 'session-b' },
+      events: [],
+      deriveMessages: () => [{
+        id: 'session-b-user',
+        role: 'user',
+        content: [{ type: 'text', text: 'Which package manager does this project use?' }],
+        source: { kind: 'user' },
+      }],
+    } as unknown as Session
+    const runtime = new StrataGateRuntime({
+      database,
+      namespaceMode: 'project',
+      namespacePrefix: 'dsh',
+      globalNamespace: 'global',
+      blockTurnSize: 2,
+      ingestSubagents: false,
+      maxOutputTokens: 2048,
+    }, fakeModels)
+    try {
+      expect(runtime.namespaceFor(sessionA)).toBe(runtime.namespaceFor(sessionB))
+      const memory = await (runtime as unknown as { space: (active: Session) => Promise<StrataGate> }).space(sessionA)
+      await memory.appendTurn({ user: 'A-only setup.', assistant: 'A reply.', threadId: 'session-a' })
+      await memory.appendTurn({ user: 'A-only sealed turn.', assistant: 'A sealed reply.', threadId: 'session-a' })
+      const blockA = memory.listBlocks()[0]!
+      const event = await memory.addEvent({
+        title: 'Project package manager',
+        summary: 'The project package manager is pnpm.',
+        sourceMessageIds: [blockA.l5Raw[0]!.id],
+        sourceBlockId: blockA.id,
+      })
+      await memory.appendTurn({ user: 'A-only open tail.', assistant: 'A tail reply.', threadId: 'session-a' })
+      await memory.appendTurn({ user: 'B-only open tail.', assistant: 'B tail reply.', threadId: 'session-b' })
+
+      const context = await runtime.buildAutoContext(sessionB)
+      expect(context).toContain('[Current conversation]\nuser: B-only open tail.')
+      expect(context).toContain('[Decayed memory blocks]\n(no sealed blocks)')
+      expect(context).not.toContain(blockA.id)
+      expect(context).not.toContain('A-only')
+      expect(context).toContain(event.id)
+
+      const blockBatch = await runtime.blocks(sessionB) as { results: unknown[] }
+      expect(blockBatch.results).toEqual([])
+      await runtime.recordUse(sessionB, 'session-local-blocks', [])
     } finally {
       await runtime.close()
       await rm(directory, { recursive: true, force: true })

--- a/integrations/deepseek-harness/tests/web.test.ts
+++ b/integrations/deepseek-harness/tests/web.test.ts
@@ -6,7 +6,7 @@ import { handleAdminRequest, type WebResponse } from '../src/web.js'
 const fullFailure = 'StrataGate model response was not valid JSON\nRaw response (full):\n' + 'x'.repeat(600)
 
 const snapshot: StrataGateSnapshot = {
-  schemaVersion: 4,
+  schemaVersion: 5,
   currentTurn: 8,
   blockTurnSize: 4,
   openTail: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "integrations/deepseek-harness": {
       "name": "stratagate-dsh",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "license": "MIT",
       "devDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",

--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -48,6 +48,7 @@ interface SpaceRow {
 interface MessageRow {
   id: string;
   block_id: string | null;
+  thread_id: string | null;
   position: number;
   role: RawMessage['role'];
   content: string;
@@ -57,6 +58,7 @@ interface MessageRow {
 
 interface BlockRow {
   id: string;
+  thread_id: string | null;
   sequence: number;
   start_turn: number;
   end_turn: number;
@@ -203,6 +205,7 @@ CREATE TABLE IF NOT EXISTS memory_spaces (
 CREATE TABLE IF NOT EXISTS blocks (
   namespace TEXT NOT NULL,
   id TEXT NOT NULL,
+  thread_id TEXT,
   sequence INTEGER NOT NULL,
   start_turn INTEGER NOT NULL,
   end_turn INTEGER NOT NULL,
@@ -227,6 +230,7 @@ CREATE TABLE IF NOT EXISTS messages (
   namespace TEXT NOT NULL,
   id TEXT NOT NULL,
   block_id TEXT,
+  thread_id TEXT,
   position INTEGER NOT NULL,
   role TEXT NOT NULL,
   content TEXT NOT NULL,
@@ -391,6 +395,11 @@ CREATE TABLE IF NOT EXISTS ingestion_receipts (
 ) STRICT;
 `;
 
+const THREAD_INDEXES = `
+CREATE INDEX IF NOT EXISTS messages_thread_idx ON messages(namespace, thread_id, position);
+CREATE INDEX IF NOT EXISTS blocks_thread_idx ON blocks(namespace, thread_id, sequence);
+`;
+
 function parseJson<T>(value: string, label: string): T {
   try {
     return JSON.parse(value) as T;
@@ -443,7 +452,7 @@ export class SqliteStorage implements StorageAdapter {
     }
 
     const messageRows = this.database.prepare(`
-      SELECT id, block_id, position, role, content, created_at, tool_calls_json
+      SELECT id, block_id, thread_id, position, role, content, created_at, tool_calls_json
       FROM messages WHERE namespace = ? ORDER BY block_id, position
     `).all(key) as unknown as MessageRow[];
     const openTail: RawMessage[] = [];
@@ -454,6 +463,7 @@ export class SqliteStorage implements StorageAdapter {
         role: row.role,
         content: row.content,
         createdAt: row.created_at,
+        ...(row.thread_id ? { threadId: row.thread_id } : {}),
         ...(row.tool_calls_json ? { toolCalls: parseJson<ToolTrace[]>(row.tool_calls_json, 'messages.tool_calls_json') } : {}),
       };
       if (row.block_id === null) openTail.push(message);
@@ -469,6 +479,7 @@ export class SqliteStorage implements StorageAdapter {
     `).all(key) as unknown as BlockRow[];
     const blocks: MemoryBlock[] = blockRows.map((row) => ({
       id: row.id,
+      ...(row.thread_id ? { threadId: row.thread_id } : {}),
       sequence: row.sequence,
       startTurn: row.start_turn,
       endTurn: row.end_turn,
@@ -733,11 +744,12 @@ export class SqliteStorage implements StorageAdapter {
 
     const insertBlock = this.database.prepare(`
       INSERT INTO blocks (
-        namespace, id, sequence, start_turn, end_turn, created_at, should_extract,
+        namespace, id, thread_id, sequence, start_turn, end_turn, created_at, should_extract,
         l0_title, l0_tags_json, l1_summary, l2_keypoints_json, l3_condensed, l4_readable,
         pointer_current_level, pointer_anchor_level, pointer_anchor_turn, last_lifted_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT (namespace, id) DO UPDATE SET
+        thread_id = excluded.thread_id,
         sequence = excluded.sequence,
         start_turn = excluded.start_turn,
         end_turn = excluded.end_turn,
@@ -758,6 +770,7 @@ export class SqliteStorage implements StorageAdapter {
       insertBlock.run(
         namespace,
         block.id,
+        block.threadId ?? null,
         block.sequence,
         block.startTurn,
         block.endTurn,
@@ -778,10 +791,11 @@ export class SqliteStorage implements StorageAdapter {
 
     const insertMessage = this.database.prepare(`
       INSERT INTO messages (
-        namespace, id, block_id, position, role, content, created_at, tool_calls_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        namespace, id, block_id, thread_id, position, role, content, created_at, tool_calls_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT (namespace, id) DO UPDATE SET
         block_id = excluded.block_id,
+        thread_id = excluded.thread_id,
         position = excluded.position,
         role = excluded.role,
         content = excluded.content,
@@ -794,6 +808,7 @@ export class SqliteStorage implements StorageAdapter {
           namespace,
           message.id,
           blockId,
+          message.threadId ?? null,
           position,
           message.role,
           message.content,
@@ -1046,9 +1061,10 @@ export class SqliteStorage implements StorageAdapter {
     if (version === 0) {
       this.immediateTransaction(() => {
         this.database.exec(SCHEMA);
+        this.database.exec(THREAD_INDEXES);
         this.database.exec(`PRAGMA user_version = ${STRATAGATE_STORAGE_SCHEMA_VERSION}`);
       });
-    } else if (version === 1 || version === 2 || version === 3) {
+    } else if (version === 1 || version === 2 || version === 3 || version === 4) {
       this.immediateTransaction(() => {
         if (version === 1) {
           const receiptColumns = this.database.prepare("PRAGMA table_info('usage_receipts')").all() as unknown as Array<{ name: string }>;
@@ -1061,12 +1077,22 @@ export class SqliteStorage implements StorageAdapter {
           this.database.exec("ALTER TABLE usage_receipts ADD COLUMN audit_json TEXT NOT NULL DEFAULT '{}'");
         }
         this.database.exec(SCHEMA);
+        const blockColumns = this.database.prepare("PRAGMA table_info('blocks')").all() as unknown as Array<{ name: string }>;
+        if (!blockColumns.some(({ name }) => name === 'thread_id')) {
+          this.database.exec('ALTER TABLE blocks ADD COLUMN thread_id TEXT');
+        }
+        const messageColumns = this.database.prepare("PRAGMA table_info('messages')").all() as unknown as Array<{ name: string }>;
+        if (!messageColumns.some(({ name }) => name === 'thread_id')) {
+          this.database.exec('ALTER TABLE messages ADD COLUMN thread_id TEXT');
+        }
+        this.database.exec(THREAD_INDEXES);
         this.database.prepare('UPDATE memory_spaces SET schema_version = ? WHERE schema_version < ?')
           .run(STRATAGATE_STORAGE_SCHEMA_VERSION, STRATAGATE_STORAGE_SCHEMA_VERSION);
         this.database.exec(`PRAGMA user_version = ${STRATAGATE_STORAGE_SCHEMA_VERSION}`);
       });
     } else if (version === STRATAGATE_STORAGE_SCHEMA_VERSION) {
       this.database.exec(SCHEMA);
+      this.database.exec(THREAD_INDEXES);
     }
     this.assertSchemaVersion();
   }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,6 @@
 import type { ElementCard, EventCard, MemoryBlock, RawMessage } from './types.js';
 
-export const STRATAGATE_STORAGE_SCHEMA_VERSION = 4;
+export const STRATAGATE_STORAGE_SCHEMA_VERSION = 5;
 
 export type ExtractionJobStatus = 'running' | 'succeeded' | 'skipped' | 'failed';
 
@@ -114,6 +114,10 @@ interface LegacySnapshotV3 extends Omit<StrataGateSnapshot, 'schemaVersion' | 'u
   usageReceipts: Array<Omit<UsageReceipt, 'audit'>>;
 }
 
+interface LegacySnapshotV4 extends Omit<StrataGateSnapshot, 'schemaVersion'> {
+  schemaVersion: 4;
+}
+
 export function normalizeSnapshot(value: unknown): StrataGateSnapshot {
   if (!value || typeof value !== 'object') throw new TypeError('Invalid StrataGate snapshot: expected an object');
   const schemaVersion = (value as { schemaVersion?: unknown }).schemaVersion;
@@ -139,6 +143,11 @@ export function normalizeSnapshot(value: unknown): StrataGateSnapshot {
   } else if (schemaVersion === 3) {
     snapshot = {
       ...structuredClone(value as LegacySnapshotV3),
+      schemaVersion: STRATAGATE_STORAGE_SCHEMA_VERSION,
+    };
+  } else if (schemaVersion === 4) {
+    snapshot = {
+      ...structuredClone(value as LegacySnapshotV4),
       schemaVersion: STRATAGATE_STORAGE_SCHEMA_VERSION,
     };
   } else if (schemaVersion === STRATAGATE_STORAGE_SCHEMA_VERSION) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -77,6 +77,7 @@ export interface TurnInput {
   user: string;
   assistant: string;
   createdAt?: string;
+  threadId?: string;
   userToolCalls?: ToolTrace[];
   assistantToolCalls?: ToolTrace[];
   receiptId?: string;
@@ -93,6 +94,7 @@ export interface AppendTurnOptions {
 
 export interface BlockContextEntry {
   id: string;
+  threadId?: string;
   turnRange: [number, number];
   level: BlockLevel;
   label: string;
@@ -319,8 +321,9 @@ export class StrataGate {
     return this.elements;
   }
 
-  listOpenTail(): readonly RawMessage[] {
-    return this.openTail;
+  listOpenTail(threadId?: string): readonly RawMessage[] {
+    if (threadId === undefined) return this.openTail;
+    return this.openTail.filter((message) => message.threadId === threadId);
   }
 
   listExtractionJobs(): readonly ExtractionJob[] {
@@ -378,12 +381,17 @@ export class StrataGate {
     if (input.receiptId !== undefined && !receiptId) {
       throw new TypeError('Turn receiptId must not be empty');
     }
+    const threadId = input.threadId?.trim();
+    if (input.threadId !== undefined && !threadId) {
+      throw new TypeError('Turn threadId must not be empty');
+    }
     const createdAt = toUtc8Iso(input.createdAt ?? this.now());
     const userMessage: RawMessage = {
       id: this.idFactory('msg'),
       role: 'user',
       content: input.user,
       createdAt,
+      ...(threadId ? { threadId } : {}),
       ...(input.userToolCalls ? { toolCalls: input.userToolCalls } : {}),
     };
     const assistantMessage: RawMessage = {
@@ -391,6 +399,7 @@ export class StrataGate {
       role: 'assistant',
       content: input.assistant,
       createdAt,
+      ...(threadId ? { threadId } : {}),
       ...(input.assistantToolCalls ? { toolCalls: input.assistantToolCalls } : {}),
     };
     const appended = await this.commitMutation(() => {
@@ -405,12 +414,12 @@ export class StrataGate {
       return { sealedBlock: null, extractedEvents: [], projectedElements: [] };
     }
 
-    if (this.openTail.filter((message) => message.role === 'user').length < this.blockTurnSize) {
+    if (this.threadOpenTail(threadId).filter((message) => message.role === 'user').length < this.blockTurnSize) {
       const projectedElements = await this.projectEligibleElements() ?? [];
       return { sealedBlock: null, extractedEvents: [], projectedElements };
     }
 
-    const sealedBlock = await this.sealOpenTail();
+    const sealedBlock = await this.sealOpenTail(threadId);
     const extractedEvents = await this.extractEligibleBlock() ?? [];
     const projectedElements = await this.projectEligibleElements() ?? [];
     return { sealedBlock, extractedEvents, projectedElements };
@@ -420,8 +429,10 @@ export class StrataGate {
     const sealedBlocks: MemoryBlock[] = [];
     const extractedEvents: EventCard[] = [];
     const projectedElements: ElementCard[] = [];
-    while (this.openTail.filter((message) => message.role === 'user').length >= this.blockTurnSize) {
-      sealedBlocks.push(await this.sealOpenTail());
+    while (true) {
+      const sealable = this.nextSealableThread();
+      if (sealable === null) break;
+      sealedBlocks.push(await this.sealOpenTail(sealable.threadId));
       extractedEvents.push(...(await this.extractEligibleBlock() ?? []));
       projectedElements.push(...(await this.projectEligibleElements() ?? []));
     }
@@ -433,7 +444,7 @@ export class StrataGate {
     }
     if (options.retrySkipped === true) {
       const skippedBlockIds = this.blocks
-        .filter((block, index) => index < this.blocks.length - 1
+        .filter((block) => this.nextBlockInThread(block) !== null
           && block.shouldExtract
           && this.extractionJobs.get(block.id)?.status === 'skipped')
         .map((block) => block.id);
@@ -683,12 +694,17 @@ export class StrataGate {
     return hits;
   }
 
-  getBlockContext(): BlockContextEntry[] {
-    return this.blocks.map((block) => {
-      const level = getDecayedBlockLevel(block.pointerAnchorLevel, block.pointerAnchorTurn, this.currentTurn);
+  getBlockContext(threadId?: string): BlockContextEntry[] {
+    const blocks = threadId === undefined
+      ? this.blocks
+      : this.blocks.filter((block) => block.threadId === threadId);
+    return blocks.map((block) => {
+      const currentTurn = block.threadId === undefined ? this.currentTurn : this.threadTurn(block.threadId);
+      const level = getDecayedBlockLevel(block.pointerAnchorLevel, block.pointerAnchorTurn, currentTurn);
       block.pointerCurrentLevel = level;
       return {
         id: block.id,
+        ...(block.threadId ? { threadId: block.threadId } : {}),
         turnRange: [block.startTurn, block.endTurn],
         level,
         label: blockLevelLabel(level),
@@ -701,14 +717,16 @@ export class StrataGate {
     return this.commitMutation(() => {
       const block = this.blocks.find((candidate) => candidate.id === id);
       if (!block) throw new Error(`Unknown block: ${id}`);
-      const current = getDecayedBlockLevel(block.pointerAnchorLevel, block.pointerAnchorTurn, this.currentTurn);
+      const currentTurn = block.threadId === undefined ? this.currentTurn : this.threadTurn(block.threadId);
+      const current = getDecayedBlockLevel(block.pointerAnchorLevel, block.pointerAnchorTurn, currentTurn);
       const level = normalizeBlockLevel(target, current);
       block.pointerCurrentLevel = level;
       block.pointerAnchorLevel = level;
-      block.pointerAnchorTurn = this.currentTurn;
+      block.pointerAnchorTurn = currentTurn;
       block.lastLiftedAt = toUtc8Iso(this.now());
       return {
         id: block.id,
+        ...(block.threadId ? { threadId: block.threadId } : {}),
         turnRange: [block.startTurn, block.endTurn] as [number, number],
         level,
         label: blockLevelLabel(level),
@@ -875,37 +893,74 @@ export class StrataGate {
     return job;
   }
 
-  private pendingBlockMessages(): RawMessage[] {
+  private threadOpenTail(threadId: string | undefined): RawMessage[] {
+    return this.openTail.filter((message) => message.threadId === threadId);
+  }
+
+  private threadBlocks(threadId: string | undefined): MemoryBlock[] {
+    return this.blocks.filter((block) => block.threadId === threadId);
+  }
+
+  private threadTurn(threadId: string): number {
+    const sealedTurns = this.threadBlocks(threadId)
+      .reduce((total, block) => total + block.l5Raw.filter((message) => message.role === 'user').length, 0);
+    return sealedTurns + this.threadOpenTail(threadId).filter((message) => message.role === 'user').length;
+  }
+
+  private nextSealableThread(): { threadId: string | undefined } | null {
+    const counts: Array<{ threadId: string | undefined; users: number }> = [];
+    for (const message of this.openTail) {
+      if (message.role !== 'user') continue;
+      let entry = counts.find((candidate) => candidate.threadId === message.threadId);
+      if (!entry) {
+        entry = { threadId: message.threadId, users: 0 };
+        counts.push(entry);
+      }
+      entry.users += 1;
+      if (entry.users >= this.blockTurnSize) return { threadId: entry.threadId };
+    }
+    return null;
+  }
+
+  private nextBlockInThread(block: MemoryBlock): MemoryBlock | null {
+    const index = this.blocks.indexOf(block);
+    return this.blocks.slice(index + 1).find((candidate) => candidate.threadId === block.threadId) ?? null;
+  }
+
+  private pendingBlockMessages(threadId: string | undefined): RawMessage[] {
+    const messages = this.threadOpenTail(threadId);
     let users = 0;
-    let end = this.openTail.length;
-    for (const [index, message] of this.openTail.entries()) {
+    let end = messages.length;
+    for (const [index, message] of messages.entries()) {
       if (message.role !== 'user') continue;
       users += 1;
       if (users !== this.blockTurnSize) continue;
-      const nextUserOffset = this.openTail.slice(index + 1).findIndex((candidate) => candidate.role === 'user');
-      end = nextUserOffset === -1 ? this.openTail.length : index + 1 + nextUserOffset;
+      const nextUserOffset = messages.slice(index + 1).findIndex((candidate) => candidate.role === 'user');
+      end = nextUserOffset === -1 ? messages.length : index + 1 + nextUserOffset;
       break;
     }
-    return this.openTail.slice(0, end);
+    return messages.slice(0, end);
   }
 
-  private async sealOpenTail(): Promise<MemoryBlock> {
-    const raw = this.pendingBlockMessages();
+  private async sealOpenTail(threadId: string | undefined): Promise<MemoryBlock> {
+    const raw = this.pendingBlockMessages(threadId);
     if (raw.filter((message) => message.role === 'user').length < this.blockTurnSize) {
       throw new Error('Open tail does not contain enough turns to seal a block');
     }
     const generated = this.summarizer ? await this.summarizer(raw) : defaultSummary(raw);
     const deterministic = deterministicBlockLayers(raw);
     const sequence = this.blocks.length + 1;
-    const startTurn = this.blocks.at(-1)?.endTurn !== undefined ? (this.blocks.at(-1)?.endTurn ?? 0) + 1 : 1;
+    const previous = this.threadBlocks(threadId).at(-1);
+    const startTurn = previous ? previous.endTurn + 1 : 1;
     const endTurn = startTurn + this.blockTurnSize - 1;
     return this.commitMutation(() => {
-      const currentRaw = this.pendingBlockMessages();
+      const currentRaw = this.pendingBlockMessages(threadId);
       if (!sameIds(currentRaw.map((message) => message.id), raw.map((message) => message.id))) {
         throw new Error('Open tail changed while the block summary was being prepared');
       }
       const block: MemoryBlock = {
         id: this.idFactory('blk'),
+        ...(threadId ? { threadId } : {}),
         sequence,
         startTurn,
         endTurn,
@@ -921,7 +976,9 @@ export class StrataGate {
         pointerAnchorTurn: endTurn,
         lastLiftedAt: null,
       };
-      this.openTail.splice(0, raw.length);
+      const sealedIds = new Set(raw.map((message) => message.id));
+      const remaining = this.openTail.filter((message) => !sealedIds.has(message.id));
+      this.openTail.splice(0, this.openTail.length, ...remaining);
       this.blocks.push(block);
       return block;
     });
@@ -929,16 +986,17 @@ export class StrataGate {
 
   private async extractEligibleBlock(options: { blockId?: string; includeSkipped?: boolean } = {}): Promise<EventCard[] | null> {
     if (!this.extractor || this.blocks.length < 2) return null;
-    const targetIndex = this.blocks.findIndex((block, index) => {
-      if (index >= this.blocks.length - 1 || !block.shouldExtract) return false;
+    const target = this.blocks.find((block) => {
+      if (this.nextBlockInThread(block) === null || !block.shouldExtract) return false;
       if (options.blockId !== undefined && block.id !== options.blockId) return false;
       const status = this.extractionJobs.get(block.id)?.status;
       return status === undefined || status === 'failed' || (options.includeSkipped === true && status === 'skipped');
     });
-    if (targetIndex < 0) return null;
-    const target = this.blocks[targetIndex];
-    const next = this.blocks[targetIndex + 1];
-    if (!target || !next) return null;
+    if (!target) return null;
+    const threadBlocks = this.threadBlocks(target.threadId);
+    const targetIndex = threadBlocks.indexOf(target);
+    const next = threadBlocks[targetIndex + 1];
+    if (!next) return null;
     const existing = this.extractionJobs.get(target.id);
     await this.commitMutation(() => {
       const currentStatus = this.extractionJobs.get(target.id)?.status;
@@ -958,7 +1016,7 @@ export class StrataGate {
     let result: Awaited<ReturnType<EventExtractor>>;
     try {
       result = await this.extractor({
-        previous: this.blocks[targetIndex - 1] ?? null,
+        previous: threadBlocks[targetIndex - 1] ?? null,
         target,
         next,
         timeline: this.events.map((event) => ({ id: event.id, title: event.title, temporal: event.temporal })),

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface RawMessage {
   role: MessageRole;
   content: string;
   createdAt: string;
+  threadId?: string;
   toolCalls?: ToolTrace[];
 }
 
@@ -28,6 +29,7 @@ export interface BlockLayers {
 
 export interface MemoryBlock extends BlockLayers {
   id: string;
+  threadId?: string;
   sequence: number;
   startTurn: number;
   endTurn: number;

--- a/tests/persistence.test.ts
+++ b/tests/persistence.test.ts
@@ -76,17 +76,17 @@ describe('SQLite persistence', () => {
     expect(ephemeral.storageRevision).toBe(0);
   });
 
-  it('creates schema version four and rejects a newer database schema', async () => {
+  it('creates schema version five and rejects a newer database schema', async () => {
     const initializedFilename = await databasePath();
     const initialized = new SqliteStorage({ filename: initializedFilename });
     await initialized.close();
     const initializedDatabase = new Database(initializedFilename, { readonly: true });
-    expect(initializedDatabase.pragma('user_version', { simple: true })).toBe(4);
+    expect(initializedDatabase.pragma('user_version', { simple: true })).toBe(5);
     initializedDatabase.close();
 
     const newerFilename = await databasePath();
     const newerDatabase = new Database(newerFilename);
-    newerDatabase.pragma('user_version = 5');
+    newerDatabase.pragma('user_version = 6');
     newerDatabase.close();
     expect(() => new SqliteStorage({ filename: newerFilename })).toThrow('newer than supported');
   });
@@ -102,8 +102,8 @@ describe('SQLite persistence', () => {
       idFactory,
       now: fixedNow,
     });
-    await first.appendTurn({ user: 'turn one', assistant: 'answer one' });
-    expect(first.listOpenTail()).toHaveLength(2);
+    await first.appendTurn({ user: 'turn one', assistant: 'answer one', threadId: 'session-a' });
+    expect(first.listOpenTail('session-a')).toHaveLength(2);
     await first.close();
 
     const second = await StrataGate.open({
@@ -114,8 +114,9 @@ describe('SQLite persistence', () => {
       now: fixedNow,
     });
     expect(second.turn).toBe(1);
-    expect(second.listOpenTail().map((message) => message.content)).toEqual(['turn one', 'answer one']);
-    const result = await second.appendTurn({ user: 'turn two', assistant: 'answer two' });
+    expect(second.listOpenTail('session-a').map((message) => message.content)).toEqual(['turn one', 'answer one']);
+    const result = await second.appendTurn({ user: 'turn two', assistant: 'answer two', threadId: 'session-a' });
+    expect(result.sealedBlock?.threadId).toBe('session-a');
     expect(result.sealedBlock?.startTurn).toBe(1);
     expect(result.sealedBlock?.endTurn).toBe(2);
     expect(second.listOpenTail()).toHaveLength(0);
@@ -359,7 +360,7 @@ describe('SQLite persistence', () => {
     const loaded = await storage.load('legacy:user');
     expect(loaded?.revision).toBe(7);
     expect(loaded?.snapshot).toMatchObject({
-      schemaVersion: 4,
+      schemaVersion: 5,
       elements: [],
       elementProjectionJobs: [],
       ingestionReceipts: [],
@@ -367,7 +368,7 @@ describe('SQLite persistence', () => {
     await storage.close();
 
     const migrated = new Database(filename, { readonly: true });
-    expect(migrated.pragma('user_version', { simple: true })).toBe(4);
+    expect(migrated.pragma('user_version', { simple: true })).toBe(5);
     expect((migrated.pragma('table_info(usage_receipts)') as Array<{ name: string }>)
       .map(({ name }) => name)).toContain('element_ids_json');
     expect((migrated.pragma('table_info(usage_receipts)') as Array<{ name: string }>)
@@ -376,6 +377,56 @@ describe('SQLite persistence', () => {
       .pluck().get()).toBe('elements');
     expect(migrated.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'ingestion_receipts'")
       .pluck().get()).toBe('ingestion_receipts');
+    migrated.close();
+  });
+
+  it('adds nullable thread ownership when migrating a schema-v4 database', async () => {
+    const filename = await databasePath();
+    const legacy = new Database(filename);
+    legacy.exec(`
+      CREATE TABLE memory_spaces (
+        namespace TEXT PRIMARY KEY, schema_version INTEGER NOT NULL, revision INTEGER NOT NULL,
+        current_turn INTEGER NOT NULL, block_turn_size INTEGER NOT NULL,
+        created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+      ) STRICT;
+      CREATE TABLE blocks (
+        namespace TEXT NOT NULL, id TEXT NOT NULL, sequence INTEGER NOT NULL,
+        start_turn INTEGER NOT NULL, end_turn INTEGER NOT NULL, created_at TEXT NOT NULL,
+        should_extract INTEGER NOT NULL, l0_title TEXT NOT NULL, l0_tags_json TEXT NOT NULL,
+        l1_summary TEXT NOT NULL, l2_keypoints_json TEXT NOT NULL, l3_condensed TEXT NOT NULL,
+        l4_readable TEXT NOT NULL, pointer_current_level INTEGER NOT NULL,
+        pointer_anchor_level INTEGER NOT NULL, pointer_anchor_turn INTEGER NOT NULL,
+        last_lifted_at TEXT, PRIMARY KEY (namespace, id), UNIQUE (namespace, sequence),
+        FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE
+      ) STRICT;
+      CREATE TABLE messages (
+        namespace TEXT NOT NULL, id TEXT NOT NULL, block_id TEXT, position INTEGER NOT NULL,
+        role TEXT NOT NULL, content TEXT NOT NULL, created_at TEXT NOT NULL, tool_calls_json TEXT,
+        PRIMARY KEY (namespace, id),
+        FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE,
+        FOREIGN KEY (namespace, block_id) REFERENCES blocks(namespace, id) ON DELETE CASCADE
+      ) STRICT;
+      CREATE TABLE usage_receipts (
+        namespace TEXT NOT NULL, receipt_id TEXT NOT NULL, event_ids_json TEXT NOT NULL,
+        element_ids_json TEXT NOT NULL DEFAULT '[]', audit_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL, PRIMARY KEY (namespace, receipt_id),
+        FOREIGN KEY (namespace) REFERENCES memory_spaces(namespace) ON DELETE CASCADE
+      ) STRICT;
+      INSERT INTO memory_spaces VALUES ('legacy:v4', 4, 3, 0, 6, '2026-01-01', '2026-01-01');
+      PRAGMA user_version = 4;
+    `);
+    legacy.close();
+
+    const storage = new SqliteStorage({ filename });
+    const loaded = await storage.load('legacy:v4');
+    expect(loaded?.snapshot.schemaVersion).toBe(5);
+    await storage.close();
+
+    const migrated = new Database(filename, { readonly: true });
+    expect((migrated.pragma('table_info(blocks)') as Array<{ name: string }>).map(({ name }) => name))
+      .toContain('thread_id');
+    expect((migrated.pragma('table_info(messages)') as Array<{ name: string }>).map(({ name }) => name))
+      .toContain('thread_id');
     migrated.close();
   });
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -116,4 +116,40 @@ describe('StrataGate lifecycle', () => {
     expect(memory.listExtractionJobs()[0]?.status).toBe('succeeded');
     expect(attempts).toBe(2);
   });
+
+  it('keeps open tails, blocks, and extraction neighbors isolated by thread', async () => {
+    const extractionPairs: string[][] = [];
+    const memory = StrataGate.inMemory({
+      blockTurnSize: 2,
+      summarizer,
+      extractor: async ({ target, next }) => {
+        extractionPairs.push([target.threadId ?? '', next.threadId ?? '']);
+        return { shouldExtract: false, reason: 'test only', events: [] };
+      },
+      idFactory: ids(),
+    });
+
+    await memory.appendTurn({ user: 'A1', assistant: 'A1 reply', threadId: 'session-a' });
+    await memory.appendTurn({ user: 'B1', assistant: 'B1 reply', threadId: 'session-b' });
+    await memory.appendTurn({ user: 'A2', assistant: 'A2 reply', threadId: 'session-a' });
+
+    expect(memory.listOpenTail('session-a')).toHaveLength(0);
+    expect(memory.listOpenTail('session-b').map(({ content }) => content)).toEqual(['B1', 'B1 reply']);
+    expect(memory.listBlocks()[0]).toMatchObject({
+      threadId: 'session-a',
+      startTurn: 1,
+      endTurn: 2,
+    });
+    expect(memory.listBlocks()[0]?.l5Raw.map(({ content }) => content)).toEqual(['A1', 'A1 reply', 'A2', 'A2 reply']);
+
+    await memory.appendTurn({ user: 'B2', assistant: 'B2 reply', threadId: 'session-b' });
+    await memory.appendTurn({ user: 'A3', assistant: 'A3 reply', threadId: 'session-a' });
+    await memory.appendTurn({ user: 'A4', assistant: 'A4 reply', threadId: 'session-a' });
+
+    expect(memory.getBlockContext('session-a')).toHaveLength(2);
+    expect(memory.getBlockContext('session-b')).toHaveLength(1);
+    expect(extractionPairs).toContainEqual(['session-a', 'session-a']);
+    expect(extractionPairs).not.toContainEqual(['session-a', 'session-b']);
+    expect(extractionPairs).not.toContainEqual(['session-b', 'session-a']);
+  });
 });


### PR DESCRIPTION
## Summary
- isolate open tails, block sealing, decay, and automatic block context per DSH session
- keep Events and Elements project-scoped for cross-session recall
- migrate SQLite storage to schema v5 with optional thread ownership
- make English README.md the unambiguous npm landing page while retaining packaged Chinese docs
- add foundational and differentiating npm discovery keywords

## Verification
- npm run check
- npm test (75 tests)
- npm run build
- npm run verify:dsh
- npm publish --workspace stratagate-dsh --dry-run --json