### PR TITLE
Add StrataGate screenshot manifest

### DIFF
--- a/integrations/deepseek-harness/screenshots.json
+++ b/integrations/deepseek-harness/screenshots.json
@@ -1,0 +1,4 @@
+[
+  "docs/assets/stratagate-knowledge-graph.png",
+  "docs/assets/stratagate-short-term-memory.png"
+]


### PR DESCRIPTION
## Summary
- add `integrations/deepseek-harness/screenshots.json` for the marketplace screenshot discovery flow
- reference the knowledge graph and layered short-term memory images stored in this plugin directory

## Validation
- manifest parses as JSON and both referenced files exist
- `git diff --check`

This follows the marketplace maintainer's new screenshot manifest format.