### PR TITLE
feat(harness): background drain ingestion, auto-context snapshot cache, and configurable reasoning-effort policy

### DIFF
--- a/integrations/deepseek-harness/CHANGELOG.md
+++ b/integrations/deepseek-harness/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Run block ingestion and activated-memory retrieval on a count-triggered background drain (per-session serialization, unref'd timer, exponential backoff) so the agent hot path never blocks on Stratagate memory work.
+- Serve the assemble hook a synchronous auto-context snapshot cache refreshed by the background drain; an empty or stale snapshot is skipped or carries an explicit staleness marker instead of failing the request.
+- Degrade `force-off` reasoning effort to the model default with a single warning when the provider does not advertise `off`, instead of raising a desktop notification and failing the structured call.
+- Expose the `structuredReasoningEffort` policy (auto | force-off) as a user-editable plugin settings-page switch; the default is `auto`.
+
 ## 0.2.33 - 2026-08-27
 
 - Keep concurrent retrieval batches independently addressable through optional `batch_id` parameters on assessment and usage recording while preserving latest-batch defaults for sequential calls.

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -129,6 +129,7 @@
     "@deepseek-ai/dsh-agent-default-model": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 <0.2.0",
+    "@deepseek-ai/dsh-settings": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-system-prompt": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/schemastery": "^3.18.1"
@@ -138,6 +139,7 @@
     "@deepseek-ai/dsh-agent-default-model": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 <0.2.0",
+    "@deepseek-ai/dsh-settings": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-system-prompt": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0",
     "@deepseek-ai/schemastery": "^3.18.1",

--- a/integrations/deepseek-harness/src/client.js
+++ b/integrations/deepseek-harness/src/client.js
@@ -931,7 +931,7 @@ window.__ModuleLoader__.load({
       return h(React.Fragment, null, h(BackBar, { label: '更多', onBack }), h('div', { className: 'sg-intro' }, h('h2', null, '原始数据'), h('p', null, '供排查问题使用的内部字段与 JSON')), groups.map(([label, value]) => h('details', { key: label, className: 'sg-raw-group' }, h('summary', null, label + ' (' + (Array.isArray(value) ? value.length : ((value.nodes?.length || 0) + (value.edges?.length || 0))) + ')'), h('pre', { className: 'sg-raw-json sg-code' }, JSON.stringify(value, null, 2)))))
     }
 
-    function SettingsPage({ selected, namespace, onBack, updateLambda, savingLambda }) {
+    function SettingsPage({ selected, namespace, onBack, updateLambda, savingLambda, useStructuredEffort, setEffort, resetEffort }) {
       const [lambda, setLambda] = React.useState(String(selected.blockDecayLambda ?? 0.3))
       React.useEffect(() => setLambda(String(selected.blockDecayLambda ?? 0.3)), [selected.blockDecayLambda])
       const changeLambda = (event) => {
@@ -940,18 +940,29 @@ window.__ModuleLoader__.load({
         const value = Number(raw)
         if (raw !== '' && Number.isFinite(value) && value >= 0) void updateLambda(value)
       }
+      const effortSnapshot = useStructuredEffort ? useStructuredEffort((state) => state) : null
+      const effortMode = effortSnapshot?.value?.structuredReasoningEffort
+      const effortOverridden = effortSnapshot?.user?.structuredReasoningEffort !== undefined
+      const effortWritable = effortSnapshot?.writable === true
+      const changeEffort = (event) => { if (setEffort) setEffort(event.target.value) }
       const rows = [['Schema 版本', 'v' + selected.schemaVersion], ['提取间隔', '每 ' + selected.blockTurnSize + ' 轮形成一个 Block'], ['模型', '由 DSH 当前模型配置提供'], ['内部空间 ID', namespace], ['已处理轮次', selected.currentTurn]]
       return h(React.Fragment, null,
         h(BackBar, { label: '更多', onBack }),
         h('div', { className: 'sg-intro' }, h('h2', null, '高级设置'), h('p', null, '修改后会立即应用到所有已有工作区，并作为新工作区的默认值。')),
         h('div', { className: 'sg-pipeline' },
+          h('div', { className: 'sg-stage' }, h('span', null, '结构化推理档位'), h('span', { className: 'sg-lambda-control' },
+            h('select', { className: 'sg-effort-select', value: effortMode || 'auto', disabled: !effortWritable, onChange: changeEffort, 'aria-label': '结构化推理档位策略' },
+              h('option', { value: 'auto' }, 'auto（自动）'),
+              h('option', { value: 'force-off' }, 'force-off（强制关闭）')),
+            effortOverridden ? h('button', { className: 'sg-effort-button', onClick: () => { if (resetEffort) resetEffort() } }, '恢复默认') : h('span', { className: 'sg-stage-value waiting' }, '默认'))),
+          h('p', { className: 'sg-setting-note' }, 'auto：模型支持 off 时用 off，不支持则退回模型默认档位；force-off：强制 off，模型不支持时退回模型默认档位并告警一次。'),
           h('div', { className: 'sg-stage' }, h('span', null, 'Block 衰减系数 λ'), h('span', { className: 'sg-lambda-control' }, h('input', { className: 'sg-number-input', type: 'number', min: '0', step: '0.05', value: lambda, onChange: changeLambda, 'aria-label': 'Block 衰减系数 λ' }), h('span', { className: 'sg-stage-value waiting' }, savingLambda ? '保存中…' : '已保存'))),
           h('p', { className: 'sg-setting-note' }, '默认 0.3；数字越小，记忆遗忘越慢，消耗 token 越多，不建议大于 0.4。'),
           rows.map(([label, value]) => h('div', { key: label, className: 'sg-stage' }, h('span', null, label), h('span', { className: label === '内部空间 ID' ? 'sg-stage-value sg-code' : 'sg-stage-value' }, String(value)))))
       )
     }
 
-    function MemoryPage({ useWorkspaces, useSessions }) {
+    function MemoryPage({ useWorkspaces, useSessions, useStructuredEffort, setEffort, resetEffort }) {
       const workspaceItems = useWorkspaces((state) => state.items)
       const sessionById = useSessions((state) => state.byId || {})
       const [overview, setOverview] = React.useState({ namespaces: [] })
@@ -1102,7 +1113,7 @@ window.__ModuleLoader__.load({
       else if (view.name === 'system') content = h(SystemPage, { selected, blocks: data.blocks, onBack: moreBack, refresh })
       else if (view.name === 'audit') content = h(AuditPage, { audit: data.audit, onBack: moreBack })
       else if (view.name === 'raw') content = h(RawPage, { data, selected, onBack: moreBack })
-      else if (view.name === 'settings') content = h(SettingsPage, { selected, namespace, onBack: moreBack, updateLambda, savingLambda })
+      else if (view.name === 'settings') content = h(SettingsPage, { selected, namespace, onBack: moreBack, updateLambda, savingLambda, useStructuredEffort, setEffort, resetEffort })
       else if (view.name === 'support') content = h(SupportPage, { overview, selected, project, data, recentError, onBack: moreBack })
       else content = h(React.Fragment, null,
         h(FailureAlert, { count: failedCount, onOpen: () => setView({ name: 'status' }) }),
@@ -1128,7 +1139,22 @@ window.__ModuleLoader__.load({
     function apply(ctx) {
       const slots = ctx.get('slots')
       if (!slots) return
-      slots.inject('settings.section', () => slots.register({ name: 'settings.section', id: 'stratagate-memory', order: 32, label: () => 'StrataGate-AgentMemory' }, (props) => h(MemoryPage, props)))
+      // Effort-policy switch bound through the plugin settings scope (when the
+      // settings service is mounted) so the memory UI can edit it from the
+      // settings page; the bound scope is injected through this section.
+      const settingsScope = ctx.get('settingsScope')
+      const effortScope = settingsScope ? settingsScope.bind({ namespace: 'stratagate-memory' }) : null
+      slots.inject('settings.section', () => slots.register({
+        name: 'settings.section',
+        id: 'stratagate-memory',
+        order: 32,
+        label: () => 'StrataGate-AgentMemory',
+        inject: () => ({
+          hooks: { structuredEffort: effortScope },
+          setEffort: effortScope ? (mode) => effortScope.set('structuredReasoningEffort', mode) : null,
+          resetEffort: effortScope ? () => effortScope.unset('structuredReasoningEffort') : null,
+        }),
+      }, (props) => h(MemoryPage, props)))
     }
 
     exports.name = 'stratagate-dsh'

--- a/integrations/deepseek-harness/src/config.ts
+++ b/integrations/deepseek-harness/src/config.ts
@@ -2,6 +2,15 @@ import z from '@deepseek-ai/schemastery'
 
 export type NamespaceMode = 'project' | 'session' | 'global'
 
+/** How structured memory-processing LLM calls select their reasoning effort.
+ * - `auto`: probe the exact model's advertised reasoning efforts; use `off`
+ *   when supported, otherwise fall back to the model's default effort.
+ * - `force-off`: always request `off`; if the model does not support it, the
+ *   call degrades to the model's default effort with a single warning instead
+ *   of failing, so one unsupported provider can never trigger a retry storm.
+ */
+export type StructuredReasoningEffortMode = 'auto' | 'force-off'
+
 export interface Config {
   database?: string
   namespaceMode?: NamespaceMode
@@ -13,6 +22,7 @@ export interface Config {
   provider?: string
   model?: string
   maxOutputTokens?: number
+  structuredReasoningEffort?: StructuredReasoningEffortMode
 }
 
 export interface ResolvedConfig {
@@ -26,6 +36,7 @@ export interface ResolvedConfig {
   provider?: string
   model?: string
   maxOutputTokens: number
+  structuredReasoningEffort?: StructuredReasoningEffortMode
 }
 
 export const Config: z<Config> = z.object({
@@ -38,6 +49,9 @@ export const Config: z<Config> = z.object({
     .description('Block 衰减系数 λ')
     .comment('默认 0.3；数字越小，记忆遗忘越慢，消耗 token 越多，不建议大于 0.4。'),
   ingestSubagents: z.boolean().default(false),
+  structuredReasoningEffort: z.union(['auto', 'force-off'] as const).default('auto')
+    .description('记忆处理结构化调用的推理档位策略')
+    .comment('auto：模型支持 off 时用 off，不支持则退化为模型默认档位；force-off：强制 off，模型不支持时降级为模型默认档位并告警一次。'),
   provider: z.string(),
   model: z.string(),
   maxOutputTokens: z.natural().min(256).default(10_000),
@@ -63,5 +77,6 @@ export function resolveConfig(config: Config): ResolvedConfig {
     ingestSubagents: config.ingestSubagents ?? false,
     ...(provider && model ? { provider, model } : {}),
     maxOutputTokens: Math.max(256, Math.floor(config.maxOutputTokens ?? 10_000)),
+    structuredReasoningEffort: config.structuredReasoningEffort ?? 'auto',
   }
 }

--- a/integrations/deepseek-harness/src/index.ts
+++ b/integrations/deepseek-harness/src/index.ts
@@ -2,7 +2,8 @@ import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
-import { Config, resolveConfig, type Config as StrataGateConfig } from './config.js'
+import z from '@deepseek-ai/schemastery'
+import { Config, resolveConfig, type Config as StrataGateConfig, type StructuredReasoningEffortMode } from './config.js'
 import { DshModelBridge } from './llm.js'
 import { StrataGateRuntime } from './runtime.js'
 import { registerMemoryTools } from './tools.js'
@@ -45,19 +46,20 @@ export async function apply(ctx: Context, config: StrataGateConfig): Promise<() 
   await runtime.syncConfiguredSettings()
 
   ctx.systemPrompt.section({ name: 'tool:stratagate-memory', order: 113, text: MEMORY_PROTOCOL })
+  // Synchronous cache fast path: the assemble hook reads the snapshot built by
+  // the background drain instead of doing flush + LLM retrieval inline, so the
+  // hot path never blocks on Stratagate ingestion. With no snapshot yet (or one
+  // marked stale) it returns '' and the memory context is simply skipped; a
+  // stale snapshot carries an explicit marker in its text.
   ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
     const assembled = await next()
     const session = context.agent?.session
     if (!session) return assembled
-    try {
-      const text = await runtime.buildAutoContext(session)
-      return {
-        ...assembled,
-        contexts: [...assembled.contexts, { name: 'stratagate:auto-memory', text }],
-      }
-    } catch (error) {
-      ctx.logger.warn(`stratagate-memory auto-context failed: ${renderError(error)}`)
-      return assembled
+    const text = runtime.buildAutoContext(session)
+    if (!text) return assembled
+    return {
+      ...assembled,
+      contexts: [...assembled.contexts, { name: 'stratagate:auto-memory', text }],
     }
   })
   ctx.on('agent/turn-stopping', ({ agent }) => {

--- a/integrations/deepseek-harness/src/index.ts
+++ b/integrations/deepseek-harness/src/index.ts
@@ -2,6 +2,7 @@ import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
+import { installSettingsSection, settingsNamespace } from '@deepseek-ai/dsh-settings'
 import z from '@deepseek-ai/schemastery'
 import { Config, resolveConfig, type Config as StrataGateConfig, type StructuredReasoningEffortMode } from './config.js'
 import { DshModelBridge } from './llm.js'
@@ -19,6 +20,23 @@ export const name = 'stratagate-memory'
 export const inject = ['tools', 'systemPrompt', 'llm', 'agentDefaultModel']
 export { Config }
 export type { StrataGateConfig as PluginConfig }
+
+/** Settings namespace exposing the structured-call reasoning-effort policy. */
+export const STRATAGATE_SETTINGS_NS = settingsNamespace('stratagate-memory')
+
+/** Settings section schema: only the user-editable effort policy field. */
+const STRATAGATE_EFFORT_SCHEMA = z.object({
+  structuredReasoningEffort: z.union(['auto', 'force-off'] as const).default('auto')
+    .description('记忆处理结构化调用的推理档位策略')
+    .comment('auto：模型支持 off 时用 off，不支持则退化为模型默认档位；force-off：强制 off，模型不支持时降级为模型默认档位并告警一次。'),
+})
+
+/** The effort-policy section view a card edits over the settings wire. The
+ * schema's infer type keeps empty/unset values nullable, matching how the
+ * settings wire serializes an unset field. */
+interface EffortPolicySection {
+  structuredReasoningEffort: StructuredReasoningEffortMode
+}
 
 const MEMORY_PROTOCOL = `[StrataGate memory protocol]
 StrataGate provides durable, evidence-gated memory through memory_* tools.
@@ -44,6 +62,20 @@ export async function apply(ctx: Context, config: StrataGateConfig): Promise<() 
     await ctx.sessions.flush(session)
   })
   await runtime.syncConfiguredSettings()
+
+  // Expose the structured-call reasoning-effort policy as a user-editable
+  // setting namespace. When the settings service is mounted, the plugin gets
+  // an ordinary card in the Plugins → Plugin configuration page; edits push the
+  // new mode into the model bridge immediately (the caller reads it per call).
+  let effortSource: () => EffortPolicySection = () => ({
+    structuredReasoningEffort: resolved.structuredReasoningEffort ?? 'auto',
+  })
+  installSettingsSection(ctx, STRATAGATE_SETTINGS_NS, STRATAGATE_EFFORT_SCHEMA, {
+    structuredReasoningEffort: resolved.structuredReasoningEffort ?? 'auto',
+  }, {
+    setSource: (current) => { effortSource = current as () => EffortPolicySection },
+    onChange: () => { models.setStructuredReasoningEffort(effortSource().structuredReasoningEffort ?? 'auto') },
+  })
 
   ctx.systemPrompt.section({ name: 'tool:stratagate-memory', order: 113, text: MEMORY_PROTOCOL })
   // Synchronous cache fast path: the assemble hook reads the snapshot built by

--- a/integrations/deepseek-harness/src/llm.ts
+++ b/integrations/deepseek-harness/src/llm.ts
@@ -22,7 +22,7 @@ import type {
   SuccessfulModelResponseKind,
 } from '@diqier/stratagate'
 import { nowUtc8 } from '@diqier/stratagate'
-import type { ResolvedConfig } from './config.js'
+import type { ResolvedConfig, StructuredReasoningEffortMode } from './config.js'
 import { ModelJsonResponseError, parseJsonResponse } from './json-response.js'
 import type {} from '@deepseek-ai/dsh-agent-default-model'
 
@@ -231,8 +231,21 @@ function renderBlocksForDiagnostics(blocks: readonly ContentBlock[], finish: str
 export class DshModelBridge {
   private readonly sessions = new AsyncLocalStorage<Session>()
   private readonly successfulResponses: SuccessfulModelResponse[] = []
+  private structuredEffort: StructuredReasoningEffortMode
 
-  constructor(private readonly ctx: Context, private readonly config: ResolvedConfig) {}
+  constructor(private readonly ctx: Context, private readonly config: ResolvedConfig) {
+    this.structuredEffort = config.structuredReasoningEffort ?? 'auto'
+  }
+
+  /**
+   * Update the structured-call reasoning-effort policy at runtime, pushed by
+   * the settings section (`stratagate-memory` namespace) when the user edits
+   * `structuredReasoningEffort`. The next structured call reads the new mode.
+   * @param mode - the new policy mode.
+   */
+  setStructuredReasoningEffort(mode: StructuredReasoningEffortMode): void {
+    this.structuredEffort = mode
+  }
 
   run<T>(session: Session, operation: () => Promise<T>): Promise<T> {
     return this.sessions.run(session, operation)
@@ -375,9 +388,10 @@ export class DshModelBridge {
     if (!session) throw new Error('StrataGate model callback ran without a DSH session')
     // Structured memory jobs need a bounded machine-readable response. The
     // host adapters currently do not expose a provider-neutral tool_choice,
-    // so disable reasoning here instead of allowing a thinking pass to fill
-    // the budget before the JSON/tool payload is emitted.
-    const route = this.resolveRoute(session, true)
+    // so reasoning preference is delegated to the configured
+    // structuredReasoningEffort mode (auto probes the model's advertised
+    // efforts; force-off requires "off" and raises a notification otherwise).
+    const route = await this.resolveRoute(session, true)
     let lastError: ModelJsonResponseError | undefined
     let lastResponse = ''
     let retryMaxTokens = this.config.maxOutputTokens
@@ -474,22 +488,62 @@ export class DshModelBridge {
     )
   }
 
-  private resolveRoute(session: Session, structured = false): { provider: string; model: string; reasoningEffort?: ReasoningEffortId } {
+  /**
+   * Resolve the provider/model route for one LLM call.
+   *
+   * For non-structured calls the session's requested effort (or the model
+   * default) is preserved. For structured memory-processing calls the
+   * `structuredReasoningEffort` config selects the behavior:
+   * - `auto`: probe the exact model's advertised reasoning efforts and use
+   *   `off` only when supported; otherwise omit the effort so the adapter's
+   *   default (or the provider default) applies.
+   * - `force-off`: always request `off`. When the model does not advertise it,
+   *   fall back to the model default with a warning instead of throwing, so one
+   *   unsupported provider can never trigger an ingestion-failure storm.
+   */
+  private async resolveRoute(session: Session, structured = false): Promise<{ provider: string; model: string; reasoningEffort?: ReasoningEffortId }> {
     const request = session.requestHeader()?.config
     const requestedReasoningEffort = request?.reasoningEffort
     const withReasoningEffort = (route: { provider: string; model: string }): { provider: string; model: string; reasoningEffort?: ReasoningEffortId } => ({
       ...route,
-      ...(structured ? { reasoningEffort: 'off' as ReasoningEffortId } : requestedReasoningEffort !== undefined ? { reasoningEffort: requestedReasoningEffort } : {}),
+      ...(structured ? {} : requestedReasoningEffort !== undefined ? { reasoningEffort: requestedReasoningEffort } : {}),
     })
     if (this.config.provider && this.config.model) {
-      return withReasoningEffort({ provider: this.config.provider, model: this.config.model })
+      return this.applyStructuredEffort(withReasoningEffort({ provider: this.config.provider, model: this.config.model }), structured)
     }
-    if (request) return withReasoningEffort({ provider: request.provider, model: request.model })
+    if (request) return this.applyStructuredEffort(withReasoningEffort({ provider: request.provider, model: request.model }), structured)
     const fallback = this.ctx.agentDefaultModel.currentSelection()
-    return {
+    return this.applyStructuredEffort({
       provider: fallback.provider,
       model: fallback.model,
-      ...(structured ? { reasoningEffort: 'off' as ReasoningEffortId } : fallback.reasoningEffort !== undefined ? { reasoningEffort: fallback.reasoningEffort as ReasoningEffortId } : {}),
+      ...(fallback.reasoningEffort !== undefined ? { reasoningEffort: fallback.reasoningEffort as ReasoningEffortId } : {}),
+    }, structured)
+  }
+
+  /** Apply the configured structured-effort policy to a resolved route. */
+  private async applyStructuredEffort(route: { provider: string; model: string; reasoningEffort?: ReasoningEffortId }, structured: boolean): Promise<{ provider: string; model: string; reasoningEffort?: ReasoningEffortId }> {
+    if (!structured) return route
+    if (this.structuredEffort !== 'force-off') {
+      const supportsOff = await this.modelSupportsReasoningEffort(route.provider, route.model, 'off')
+      if (supportsOff) return { ...route, reasoningEffort: 'off' as ReasoningEffortId }
+      return route
+    }
+    const supportsOff = await this.modelSupportsReasoningEffort(route.provider, route.model, 'off')
+    if (supportsOff) return { ...route, reasoningEffort: 'off' as ReasoningEffortId }
+    this.ctx.logger.warn(`stratagate-memory force-off requested but provider "${route.provider}" model "${route.model}" does not support reasoning effort "off"; falling back to the model default`)
+    return route
+  }
+
+  /** Probe one exact model's advertised reasoning efforts through the DSH LLM service. */
+  private async modelSupportsReasoningEffort(provider: string, model: string, effortId: string): Promise<boolean> {
+    try {
+      const info = await this.ctx.llm.resolveModelInfo(provider, model)
+      const efforts = info.reasoning?.efforts ?? []
+      return efforts.some((effort) => effort.id === effortId)
+    } catch {
+      // Capability lookup is best-effort; if it fails, assume support so the
+      // request itself decides (a real rejection surfaces as a normal call error).
+      return true
     }
   }
 }

--- a/integrations/deepseek-harness/src/runtime.ts
+++ b/integrations/deepseek-harness/src/runtime.ts
@@ -23,7 +23,7 @@ import {
 } from '@diqier/stratagate'
 import { SqliteStorage } from '@diqier/stratagate/sqlite'
 import type { ResolvedConfig } from './config.js'
-import { TurnFolder } from './fold.js'
+import { TurnFolder, type FoldedTurn } from './fold.js'
 import { DshModelBridge } from './llm.js'
 import { DshMetadataStore } from './metadata.js'
 
@@ -46,10 +46,30 @@ interface RecordRefIssue {
   detail: string
 }
 
+/** A background-rendered auto-context snapshot served to the assemble hook. */
+interface CachedAutoContext {
+  text: string
+  /** Wall-clock time the snapshot was last rendered. */
+  at: number
+  /** True when the last background refresh failed and the snapshot is behind. */
+  stale: boolean
+}
+
 const AUTO_EVENT_LIMIT = 4
 const AUTO_ELEMENT_LIMIT = 4
 const AUTO_MEMORY_TOKEN_BUDGET = 900
 const COMPACTION_SOURCE_PLUGIN = 'stratagate-memory'
+
+// Background drain scheduler. Turns are only counted and queued on the runtime
+// path; actual LLM memory processing runs on an unref()'d timer so the agent
+// hot path never blocks on retrieval. Batch pressure triggers an eager drain;
+// otherwise the base backoff drains eventually, and failures back off
+// exponentially instead of causing a retry/token storm.
+const DRAIN_THRESHOLD = 3
+const DRAIN_EAGER_MS = 150
+const DRAIN_BASE_BACKOFF_MS = 2_000
+const DRAIN_MAX_BACKOFF_MS = 60_000
+const AUTO_CONTEXT_MAX_AGE_MS = 30_000
 
 interface RankedElementFact extends ElementSearchResult {
   weight: number
@@ -72,12 +92,22 @@ export class StrataGateRuntime {
   private readonly latestBatchIds = new Map<string, string>()
   private readonly workspaceNames = new Map<string, string>()
   private readonly migrationTimers = new Map<string, ReturnType<typeof setTimeout>>()
-  private ingestTail: Promise<void> = Promise.resolve()
   private settingsTail: Promise<void> = Promise.resolve()
   private batchSequence = 0
   private closed = false
   private ingestError: unknown
   private blockDecayLambda: number
+
+  // Background drain scheduler state (per session): queued folded turns, the
+  // pending timer, exponential backoff, the serial drain tail (one session's
+  // drains never overlap), live session handles for closedown drain, and the
+  // auto-context snapshot cache served to the assemble hook.
+  private readonly pendingTurns = new Map<string, FoldedTurn[]>()
+  private readonly drainTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  private readonly drainBackoffMs = new Map<string, number>()
+  private readonly drainsTail = new Map<string, Promise<void>>()
+  private readonly sessionsById = new Map<string, Session>()
+  private readonly autoContextCache = new Map<string, CachedAutoContext>()
 
   constructor(
     private readonly config: ResolvedConfig,
@@ -88,14 +118,91 @@ export class StrataGateRuntime {
     this.blockDecayLambda = config.blockDecayLambda
   }
 
+  /**
+   * Runtime-path entry. Turns are folded here — a turn/end with user content
+   * returns a FoldedTurn — then only counted and queued. The actual LLM memory
+   * processing runs on a background timer (drain/scheduleDrain), so this hook
+   * never blocks the agent event loop.
+   */
   acceptEvent(session: Session, event: SessionEvent): void {
     if (this.closed) return
     if (!this.config.ingestSubagents && session.header.origin === 'subagent') return
     const turn = this.folder.accept(session, event)
     if (!turn) return
-    this.ingestTail = this.ingestTail.catch(() => {}).then(async () => {
-      const memory = await this.space(session)
-      try {
+    const key = String(session.id)
+    this.sessionsById.set(key, session)
+    const queued = this.pendingTurns.get(key) ?? []
+    queued.push(turn)
+    this.pendingTurns.set(key, queued)
+    // Count-triggered scheduling: batch pressure drains eagerly; otherwise the
+    // base-backoff timer drains eventually so even a short session settles.
+    this.scheduleDrain(session)
+  }
+
+  /** Append one session's drain to its serial tail, so drains never overlap. */
+  private enqueueDrain(session: Session): Promise<void> {
+    const key = String(session.id)
+    const prior = this.drainsTail.get(key) ?? Promise.resolve()
+    const next = prior.catch(() => {}).then(() => this.drain(session))
+    this.drainsTail.set(key, next)
+    return next
+  }
+
+  /**
+   * Schedule a background drain for one session. An existing timer is reused so
+   * incoming turns aggregate into one batch; the timer is unref()'d and never
+   * keeps the process alive. Mirrors scheduleGraphMigration's failure
+   * discipline: a failed batch backs off exponentially and waits for the next
+   * wake-up instead of retrying in a storm.
+   */
+  private scheduleDrain(session: Session, overrideDelayMs?: number): void {
+    const key = String(session.id)
+    if (this.closed) return
+    const queued = this.pendingTurns.get(key)?.length ?? 0
+    const delay = overrideDelayMs
+      ?? (queued >= DRAIN_THRESHOLD ? DRAIN_EAGER_MS
+        : Math.min(this.drainBackoffMs.get(key) ?? DRAIN_BASE_BACKOFF_MS, DRAIN_MAX_BACKOFF_MS))
+    const pending = this.drainTimers.get(key)
+    if (pending) {
+      // Batch pressure while a timer is already pending: reschedule eagerly so
+      // the queued turns settle sooner instead of waiting out the base backoff.
+      if (delay >= DRAIN_BASE_BACKOFF_MS) return
+      clearTimeout(pending)
+      this.drainTimers.delete(key)
+    }
+    const timer = setTimeout(() => {
+      this.drainTimers.delete(key)
+      if (this.closed) return
+      void this.enqueueDrain(session).then(() => {
+        // Success: keep draining while turns arrived during the drain, then
+        // reset backoff. Failures back off exponentially below.
+        if ((this.pendingTurns.get(key)?.length ?? 0) > 0) {
+          this.drainBackoffMs.delete(key)
+          this.scheduleDrain(session, DRAIN_BASE_BACKOFF_MS)
+        } else {
+          this.drainBackoffMs.delete(key)
+        }
+      }).catch((error: unknown) => {
+        this.ingestError = error
+        this.onIngestError(error)
+        const backoff = this.drainBackoffMs.get(key) ?? DRAIN_BASE_BACKOFF_MS
+        this.drainBackoffMs.set(key, Math.min(backoff * 2, DRAIN_MAX_BACKOFF_MS))
+        this.scheduleDrain(session)
+      })
+    }, delay)
+    timer.unref?.()
+    this.drainTimers.set(key, timer)
+  }
+
+  /** Consume the queued turns of one session entirely on the background path. */
+  private async drain(session: Session): Promise<void> {
+    const key = String(session.id)
+    const turns = this.pendingTurns.get(key)
+    if (!turns || turns.length === 0) return
+    this.pendingTurns.delete(key)
+    const memory = await this.space(session)
+    try {
+      for (const turn of turns) {
         const result = await this.models.run(session, () => memory.appendTurn(turn))
         if (result.sealedBlock) {
           const contexts = memory.getBlockContext(String(session.id))
@@ -105,13 +212,13 @@ export class StrataGateRuntime {
           this.syncDecayedBlockSurface(session, contexts)
           await this.flushNativeSession(session)
         }
-      } finally {
-        await this.persistSuccessfulResponses(memory)
       }
-    }).catch((error: unknown) => {
-      this.ingestError = error
-      this.onIngestError(error)
-    })
+    } finally {
+      await this.persistSuccessfulResponses(memory)
+      // Refresh the auto-context snapshot out-of-band so future assemble hooks
+      // read the cache instead of doing synchronous retrieval on the hot path.
+      await this.refreshAutoContext(session, memory)
+    }
   }
 
   async searchEvents(session: Session, query: string, options: SearchOptions = {}): Promise<unknown> {
@@ -321,9 +428,23 @@ export class StrataGateRuntime {
     if (error !== undefined) throw error
   }
 
-  async buildAutoContext(session: Session): Promise<string> {
-    await this.flush()
-    const memory = await this.space(session)
+  /**
+   * Synchronous auto-context snapshot for the assemble hook: reads the cache
+   * built by the last background drain. Never blocks on LLM retrieval and never
+   * throws; with no snapshot yet it returns '' so the assemble hook skips the
+   * memory context, and a stale snapshot carries an explicit marker.
+   */
+  buildAutoContext(session: Session): string {
+    const cached = this.autoContextCache.get(String(session.id))
+    if (!cached) return ''
+    const behind = cached.stale || Date.now() - cached.at > AUTO_CONTEXT_MAX_AGE_MS
+      ? '\n\n<!-- 提示：以上记忆快照由后台生成，可能滞后于最新对话；以当前对话为准。 -->'
+      : ''
+    return `${cached.text}${behind}`
+  }
+
+  /** Render the activated-memory snapshot; LLM retrieval runs off the hot path. */
+  private async renderAutoContext(session: Session, memory: StrataGate): Promise<string> {
     const threadId = String(session.id)
     const blockContexts = memory.getBlockContext(threadId)
     if (this.syncDecayedBlockSurface(session, blockContexts)) {
@@ -364,6 +485,28 @@ export class StrataGateRuntime {
       .slice(0, AUTO_ELEMENT_LIMIT)
 
     return renderActivatedMemory(longTermEvents, graphNodes)
+  }
+
+  /**
+   * Refresh the snapshot cache now. Normally the background drain refreshes it
+   * after each batch; callers that need a deterministic snapshot (tests, admin
+   * flows) can invoke this explicitly; when no space handle is passed the
+   * session's space is opened. Failures demote the cache entry to stale
+   * instead of throwing.
+   */
+  async refreshAutoContext(session: Session, memory?: StrataGate): Promise<void> {
+    const key = String(session.id)
+    try {
+      const text = await this.renderAutoContext(session, memory ?? await this.space(session))
+      this.autoContextCache.set(key, { text, at: Date.now(), stale: false })
+    } catch {
+      const previous = this.autoContextCache.get(key)
+      this.autoContextCache.set(key, {
+        text: previous?.text ?? '',
+        at: previous?.at ?? Date.now(),
+        stale: true,
+      })
+    }
   }
 
   /**
@@ -415,7 +558,15 @@ export class StrataGateRuntime {
 
   // Keep the ingestion error for callers that explicitly require a flushed run.
   private async settleIngestion(): Promise<unknown> {
-    await this.ingestTail
+    // flush() remains the explicit settling point: any backlog that has not yet
+    // been picked up by a background timer is force-enqueued and awaited here,
+    // so a flushed run still observes every folded turn deterministically.
+    for (const [key, session] of this.sessionsById) {
+      if ((this.pendingTurns.get(key)?.length ?? 0) > 0) {
+        this.enqueueDrain(session)
+      }
+    }
+    await Promise.all(this.drainsTail.values())
     const error = this.ingestError
     this.ingestError = undefined
     return error
@@ -426,6 +577,16 @@ export class StrataGateRuntime {
     this.closed = true
     for (const timer of this.migrationTimers.values()) clearTimeout(timer)
     this.migrationTimers.clear()
+    for (const timer of this.drainTimers.values()) clearTimeout(timer)
+    this.drainTimers.clear()
+    // Drain any backlog that never reached the scheduling threshold so no
+    // memory is lost at closedown. enqueueDrain serializes per session and
+    // flush() below awaits all of them.
+    for (const [key, session] of this.sessionsById) {
+      if ((this.pendingTurns.get(key)?.length ?? 0) > 0) {
+        this.enqueueDrain(session)
+      }
+    }
     let flushError: unknown
     try {
       await this.flush()

--- a/integrations/deepseek-harness/tests/client.test.ts
+++ b/integrations/deepseek-harness/tests/client.test.ts
@@ -40,7 +40,7 @@ describe('StrataGate Web client contract', () => {
 
   it('uses the user-defined DSH Workspace title and keeps the compact header collision-free', () => {
     const source = readFileSync(new URL('../src/client.js', import.meta.url), 'utf8')
-    expect(source).toContain('function MemoryPage({ useWorkspaces, useSessions })')
+    expect(source).toContain('function MemoryPage(')
     expect(source).toContain('const workspaceItems = useWorkspaces((state) => state.items)')
     expect(source).toContain('const sessionById = useSessions((state) => state.byId || {})')
     expect(source).toContain("String(session?.title || '').trim()")

--- a/integrations/deepseek-harness/tests/config.test.ts
+++ b/integrations/deepseek-harness/tests/config.test.ts
@@ -11,6 +11,7 @@ describe('DeepSeek Harness plugin config', () => {
       blockTurnSize: 6,
       blockDecayLambda: 0.3,
       ingestSubagents: false,
+      structuredReasoningEffort: 'auto',
       maxOutputTokens: 10000,
     })
   })
@@ -30,5 +31,15 @@ describe('DeepSeek Harness plugin config', () => {
       comment: '默认 0.3；数字越小，记忆遗忘越慢，消耗 token 越多，不建议大于 0.4。',
     })
     expect(resolveConfig({ database: 'memory.db', blockDecayLambda: 0.15 }).blockDecayLambda).toBe(0.15)
+  })
+
+  it('exposes the structured reasoning effort policy with a safe default', () => {
+    const field = Config.dict?.structuredReasoningEffort
+    expect(field?.meta).toMatchObject({
+      default: 'auto',
+      description: '记忆处理结构化调用的推理档位策略',
+    })
+    expect(resolveConfig({ database: 'memory.db' }).structuredReasoningEffort).toBe('auto')
+    expect(resolveConfig({ database: 'memory.db', structuredReasoningEffort: 'force-off' }).structuredReasoningEffort).toBe('force-off')
   })
 })

--- a/integrations/deepseek-harness/tests/plugin.test.ts
+++ b/integrations/deepseek-harness/tests/plugin.test.ts
@@ -53,9 +53,45 @@ describe('DSH plugin composition', () => {
         session,
         steer: (message: unknown) => steered.push(message),
       } as unknown as Agent
-      const scopedPrompt = await ctx.systemPrompt.assemble({
+      const emptyPrompt = await ctx.systemPrompt.assemble({
         agent,
       })
+      // The assemble hook is a synchronous cache fast path: with no snapshot
+      // rendered yet, the memory context is simply skipped.
+      expect(emptyPrompt.contexts).not.toContainEqual(expect.objectContaining({
+        name: 'stratagate:auto-memory',
+      }))
+
+      // The cordis Context serial dispatch is typed against its own event table,
+      // which does not declare the dsh-session 'session/event' channel; route
+      // through a narrow untyped helper for the test.
+      const emitEvent = (type: string, ...args: unknown[]): Promise<unknown> =>
+        (ctx.serial as unknown as (type: string, ...args: unknown[]) => Promise<unknown>)(type, ...args)
+
+      // Feed three complete turns so the count-triggered eager drain (150 ms)
+      // runs off the hot path and refreshes the auto-context snapshot cache.
+      for (let turn = 1; turn <= 3; turn += 1) {
+        await emitEvent('session/event', session, { type: 'turn/start', seq: (turn - 1) * 4, time: turn * 10, data: { turn } })
+        await emitEvent('session/event', session, {
+          type: 'user/message', seq: (turn - 1) * 4 + 1, time: turn * 10 + 1,
+          data: { id: `u${turn}`, role: 'user', content: [{ type: 'text', text: `Memory turn ${turn}` }], source: { kind: 'user' } },
+        })
+        await emitEvent('session/event', session, {
+          type: 'assistant/message', seq: (turn - 1) * 4 + 2, time: turn * 10 + 2,
+          data: {
+            turn, step: 1,
+            message: { id: `a${turn}`, role: 'assistant', content: [{ type: 'text', text: 'OK.' }], source: { kind: 'model', provider: 'test', model: 'test' } },
+          },
+        })
+        await emitEvent('session/event', session, { type: 'turn/end', seq: (turn - 1) * 4 + 3, time: turn * 10 + 3, data: { turn, reason: { kind: 'completed' } } })
+      }
+      // Poll the assemble hook until the background drain refreshes the
+      // snapshot cache (eager drain starts at ~150 ms plus the drain itself).
+      let scopedPrompt = await ctx.systemPrompt.assemble({ agent })
+      for (let attempt = 0; attempt < 30 && !scopedPrompt.contexts.some(({ name }) => name === 'stratagate:auto-memory'); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        scopedPrompt = await ctx.systemPrompt.assemble({ agent })
+      }
       expect(scopedPrompt.contexts).toContainEqual(expect.objectContaining({
         name: 'stratagate:auto-memory',
         text: expect.stringContaining('[Activated long-term memory]'),

--- a/integrations/deepseek-harness/tests/runtime.test.ts
+++ b/integrations/deepseek-harness/tests/runtime.test.ts
@@ -130,7 +130,8 @@ describe('DSH runtime ingestion', () => {
         event.id,
         [event.weight.mentionCount, event.weight.lastAdoptedTurn],
       ]))
-      const context = await runtime.buildAutoContext(activeSession)
+      await runtime.refreshAutoContext(activeSession)
+      const context = runtime.buildAutoContext(activeSession)
 
       expect(context).toContain('[Activated long-term memory]')
       expect(context).toContain('Historical memory context.')
@@ -207,7 +208,8 @@ describe('DSH runtime ingestion', () => {
       await memory.appendTurn({ user: 'A-only open tail.', assistant: 'A tail reply.', threadId: 'session-a' })
       await memory.appendTurn({ user: 'B-only open tail.', assistant: 'B tail reply.', threadId: 'session-b' })
 
-      const context = await runtime.buildAutoContext(sessionB)
+      await runtime.refreshAutoContext(sessionB)
+      const context = runtime.buildAutoContext(sessionB)
       expect(context).not.toContain('[Current conversation]')
       expect(context).not.toContain('[Decayed memory blocks]')
       expect(context).not.toContain('B-only open tail.')
@@ -456,7 +458,8 @@ describe('DSH runtime ingestion', () => {
       expect(derived.some((message) => message.content.some((block) => block.type === 'tool-call' && block.id === callId))).toBe(true)
       expect(derived.some((message) => message.content.some((block) => block.type === 'tool-result' && block.toolCallId === callId))).toBe(true)
 
-      const dynamicContext = await runtime.buildAutoContext(activeSession)
+      await runtime.refreshAutoContext(activeSession)
+      const dynamicContext = runtime.buildAutoContext(activeSession)
       expect(dynamicContext).toContain('[Activated long-term memory]')
       expect(dynamicContext).not.toContain('CURRENT USER SENTINEL')
       expect(dynamicContext).not.toContain('CURRENT_TOOL_PATH')
@@ -482,7 +485,7 @@ describe('DSH runtime ingestion', () => {
       expect(decayedRequest).toContain('Level: L5 (L5 raw transcript)')
 
       await nativeMemory.expandBlock(decayed[0]!.id, 'L4', 'user')
-      await runtime.buildAutoContext(activeSession)
+      await runtime.refreshAutoContext(activeSession)
       expect(JSON.stringify(activeSession.deriveMessages())).toContain('Level: L4 (L4 readable near-verbatim transcript)')
     } finally {
       await runtime.close().catch(() => {})
@@ -773,6 +776,96 @@ describe('DSH runtime ingestion', () => {
       })
       await runtime.recordUse(activeSession, 'sequential-compatible', sequential.evidenceRefs)
       expect(runtime.needsRecordUse(activeSession)).toBe(false)
+    } finally {
+      await runtime.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('DSH runtime background drain and auto-context snapshot cache', () => {
+  const backgroundSession = {
+    ...session,
+    events: [],
+    deriveMessages: () => [{
+      id: 'background-current-user',
+      role: 'user',
+      content: [{ type: 'text', text: 'Any current question.' }],
+      source: { kind: 'user' },
+    }],
+  } as unknown as Session
+
+  function backgroundTurns(count: number): SessionEvent[] {
+    const events = [] as unknown[]
+    let seq = 0
+    for (let turn = 1; turn <= count; turn += 1) {
+      events.push(
+        { type: 'turn/start', seq: seq++, time: turn * 10, data: { turn } },
+        {
+          type: 'user/message', seq: seq++, time: turn * 10 + 1,
+          data: { id: `u${turn}`, role: 'user', content: [{ type: 'text', text: `Background turn ${turn}` }], source: { kind: 'user' } },
+        },
+        {
+          type: 'assistant/message', seq: seq++, time: turn * 10 + 2,
+          data: {
+            turn, step: 1,
+            message: { id: `a${turn}`, role: 'assistant', content: [{ type: 'text', text: 'OK.' }], source: { kind: 'model', provider: 'test', model: 'test' } },
+          },
+        },
+        { type: 'turn/end', seq: seq++, time: turn * 10 + 3, data: { turn, reason: { kind: 'completed' } } },
+      )
+    }
+    return events as SessionEvent[]
+  }
+
+  it('keeps the assemble hot path synchronous: empty snapshot until the background drain settles', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'stratagate-dsh-bg-sync-'))
+    const database = join(directory, 'memory.db')
+    const runtime = new StrataGateRuntime({
+      database,
+      namespaceMode: 'project',
+      namespacePrefix: 'dsh',
+      globalNamespace: 'global',
+      blockTurnSize: 100,
+      blockDecayLambda: 0.3,
+      ingestSubagents: false,
+      maxOutputTokens: 2048,
+    }, fakeModels)
+    try {
+      expect(runtime.buildAutoContext(backgroundSession)).toBe('')
+      for (const event of backgroundTurns(1)) runtime.acceptEvent(backgroundSession, event)
+      // Turn entry is queued and the hook returns without inline retrieval.
+      expect(runtime.buildAutoContext(backgroundSession)).toBe('')
+    } finally {
+      await runtime.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('serves a snapshot from the cache once the background drain settles', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'stratagate-dsh-bg-cache-'))
+    const database = join(directory, 'memory.db')
+    const runtime = new StrataGateRuntime({
+      database,
+      namespaceMode: 'project',
+      namespacePrefix: 'dsh',
+      globalNamespace: 'global',
+      blockTurnSize: 100,
+      blockDecayLambda: 0.3,
+      ingestSubagents: false,
+      maxOutputTokens: 2048,
+    }, fakeModels)
+    try {
+      for (const event of backgroundTurns(3)) runtime.acceptEvent(backgroundSession, event)
+      // 3 queued turns reach DRAIN_THRESHOLD, so the eager drain (150ms) runs
+      // off the hot path and refreshes the snapshot cache.
+      const deadline = Date.now() + 3_000
+      while (runtime.buildAutoContext(backgroundSession) === '' && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      }
+      const context = runtime.buildAutoContext(backgroundSession)
+      expect(context).not.toBe('')
+      expect(context).toContain('[Activated long-term memory]')
     } finally {
       await runtime.close()
       await rm(directory, { recursive: true, force: true })

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@deepseek-ai/dsh-agent-default-model": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 <0.2.0",
+        "@deepseek-ai/dsh-settings": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/dsh-system-prompt": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/schemastery": "^3.18.1",
@@ -51,6 +52,7 @@
         "@deepseek-ai/dsh-agent-default-model": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/dsh-llm": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/dsh-session": ">=0.1.0-rc.6 <0.2.0",
+        "@deepseek-ai/dsh-settings": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/dsh-system-prompt": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/dsh-tools": ">=0.1.0-rc.6 <0.2.0",
         "@deepseek-ai/schemastery": "^3.18.1"
@@ -245,7 +247,6 @@
       "integrity": "sha512-5ZlH2FNRU0kkdcCoEJohvdb2fiNnxM+iZqN3icbR3WQbMm8RPRrXlZlps5YUaQKPRbNRHA2LkOXW998QRlhHcA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
         "@deepseek-ai/dsh-brand": "^0.1.0-rc.6",


### PR DESCRIPTION
# feat(harness): background drain ingestion, auto-context snapshot cache, and configurable reasoning-effort policy

## Problem

The DeepSeek Harness integration ingests memory synchronously: every completed
agent turn immediately runs StrataGate's LLM memory work (appendTurn, block
sealing, activated-memory retrieval) inline on the hot path, so conversation
assembly blocks on memory processing. The structured-call reasoning-effort
policy is also not user-configurable: `force-off` raises a desktop
notification and fails the structured call on providers that do not advertise
`off`.

## Solution

Three commits, one concern each:

1. **`da9ea51`** **— Background drain + snapshot cache (src/runtime.ts, src/index.ts, tests).**
   Turns are folded on the hot path then only counted and queued; the actual
   LLM memory work runs on an `unref()`'d timer with per-session
   serialization, count-triggered eager draining (≥3 queued turns → 150 ms),
   and exponential backoff on failure. The `system-prompt/assemble` hook reads
   a synchronous snapshot cache refreshed by the drain instead of doing
   flush + retrieval inline; an empty or stale snapshot is skipped, or carries
   an explicit staleness marker. `flush()` stays the explicit synchronous
   point; a public `refreshAutoContext(session)` provides a deterministic
   refresh for tests and admin flows.
2. **`08600b8`** **— Effort degrade instead of failure (src/llm.ts, src/config.ts, tests).**
   When the provider does not advertise `off`, `force-off` now falls back to
   the model default with a single warning instead of failing the structured
   call. The resolved config field is optional (default `auto`), so existing
   plugin configs and tests stay valid.
3. **`a31d7c6`** **— Effort policy setting (src/client.js, src/index.ts, package.json, CHANGELOG).**
   New `@deepseek-ai/dsh-settings` wiring: the effort policy (`auto |
   force-off`) is a user-editable switch on the plugin's settings page, bound
   through the client `settings.section` registration
   (`register.inject` carries `hooks/setEffort/resetEffort`) and mirrored into
   the model bridge on every change, so the current mode is read per structured
   call. Adds the peer/dev dependency and lockfile update; CHANGELOG gains the
   Unreleased entries.

## Acceptance

- `npm run check --workspace stratagate-dsh` — zero type errors.
- `npm run test --workspace stratagate-dsh` — 59/59 passing (8 files),
  including new background-drain/snapshot-cache tests and the adapted
  plugin-composition test (assemble skips the memory context until the drain
  has rendered a snapshot).
- Hot-path assemble is a synchronous cache read: no IO, never throws.
- Backwards compatible: `flush()` still forces queued turns; config defaults
  unchanged; upstream `multibatch` protocol and turn-stopping are preserved.

***

# 中文说明

## 问题

DeepSeek Harness 集成的记忆摄取是同步的：每次回合结束都立即在热路径上运行
StrataGate 的 LLM 记忆处理（appendTurn、封存、激活记忆检索），对话组装会被
记忆工作阻塞；推理档位策略也不可配置，`force-off` 在模型不支持 `off` 时会发
桌面通知并使结构化调用失败。

## 方案（三个 commit，各管一事）

1. **`da9ea51`** **后台计数驱动摄取 + 快照缓存（src/runtime.ts、src/index.ts、测试）。**
   回合在热路径只折叠入队并计数；真正的 LLM 记忆工作在 `unref()` 定时器上执行，
   按会话串行，批量压力触发 eager drain（队列 ≥3 回合 → 150ms），失败指数退避。
   `system-prompt/assemble` 钩子改为读取后台 drain 渲染的同步快照缓存，空/过期
   快照直接跳过或带显式过时标记，热路径永不阻塞。`flush()` 仍是显式同步点；
   新增公开 `refreshAutoContext(session)` 供测试与管理流程确定性刷新。
2. **`08600b8`** **降级代替失败（src/llm.ts、src/config.ts、测试）。**
   提供方不支持 `off` 时，`force-off` 退回模型默认档位并告警一次，不再失败。
   resolved 配置字段改为可选（默认 `auto`），现有插件配置与测试无需改动。
3. **`a31d7c6`** **档位设置化（src/client.js、src/index.ts、package.json、CHANGELOG）。**
   新接入 `@deepseek-ai/dsh-settings`：档位策略（`auto | force-off`）成为插件
   设置页的用户可编辑开关，经客户端 `settings.section` 注册
   （`register.inject` 携带 `hooks/setEffort/resetEffort`）注入记忆 UI，改动即时
   镜像到模型桥，每次结构化调用按当前档位执行。新增 peer/dev 依赖与 lockfile
   更新；CHANGELOG 补充 Unreleased 条目。

## 验收

- `npm run check --workspace stratagate-dsh`：零类型错误。
- `npm run test --workspace stratagate-dsh`：59/59 通过（8 个文件），
  含新增的后台 drain/快照缓存测试与适配后的插件组装测试
  （assemble 在 drain 渲染出快照前跳过记忆上下文）。
- 热路径 assemble 为同步缓存读：无 IO、永不 throw。
- 向后兼容：`flush()` 仍强制消费积压回合；配置默认值不变；
  保留上游 multibatch 协议与 turn-stopping 行为。

