### PR TITLE
Publish an evergreen DSH release asset

### DIFF
--- a/.github/workflows/release-dsh.yml
+++ b/.github/workflows/release-dsh.yml
@@ -48,14 +48,24 @@ jobs:
       - run: npm run test:dsh
       - run: npm run build:dsh
       - run: npm run verify:dsh
-      - run: npm publish --workspace stratagate-dsh --provenance --access public
+      - name: Pack release assets from one artifact
+        shell: bash
+        run: |
+          version="$(node -p 'require("./integrations/deepseek-harness/package.json").version')"
+          versioned="stratagate-dsh-${version}.tgz"
+          npm pack --workspace stratagate-dsh --silent
+          test -f "$versioned"
+          cp "$versioned" stratagate-dsh.tgz
+          cmp "$versioned" stratagate-dsh.tgz
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+      - name: Publish exact package artifact
+        run: npm publish "stratagate-dsh-${VERSION}.tgz" --provenance --access public
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          version="$(node -p 'require("./integrations/deepseek-harness/package.json").version')"
-          gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes --title "StrataGate DSH $version"
+          gh release create "$GITHUB_REF_NAME" "stratagate-dsh-${VERSION}.tgz" stratagate-dsh.tgz --verify-tag --generate-notes --title "StrataGate DSH $VERSION"
 
   publish-artifact:
     if: github.event_name == 'workflow_dispatch'
@@ -81,6 +91,8 @@ jobs:
           tar -xOf "$filename" package/package.json > package-manifest.json
           test "$(node -p 'require("./package-manifest.json").name')" = "stratagate-dsh"
           test "$(node -p 'require("./package-manifest.json").version')" = "$VERSION"
+          cp "$filename" stratagate-dsh.tgz
+          cmp "$filename" stratagate-dsh.tgz
       - name: Publish exact package artifact
         run: npm publish "stratagate-dsh-${VERSION}.tgz" --provenance --access public
       - name: Create GitHub release with verified artifact
@@ -88,4 +100,4 @@ jobs:
         run: |
           tag="stratagate-dsh-v${VERSION}"
           filename="stratagate-dsh-${VERSION}.tgz"
-          gh release create "$tag" "$filename" --repo "$GITHUB_REPOSITORY" --target "$GITHUB_SHA" --generate-notes --title "StrataGate DSH $VERSION"
+          gh release create "$tag" "$filename" stratagate-dsh.tgz --repo "$GITHUB_REPOSITORY" --target "$GITHUB_SHA" --generate-notes --title "StrataGate DSH $VERSION"


### PR DESCRIPTION
## Summary

- pack the DSH npm artifact once and publish that exact tarball
- attach both the versioned filename and fixed stratagate-dsh.tgz alias to every GitHub Release
- apply the same fixed-name asset rule to staged artifact releases

## Verification

- npm run check:dsh
- npm run test:dsh (56 tests)
- npm run build:dsh
- npm run verify:dsh
- verified both asset names have identical SHA-256 hashes
- parsed the workflow YAML and ran git diff --check