### PR TITLE
docs: add contributor guides and badges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to StrataGate
+
+Thank you for helping improve StrataGate. Contributions of code, tests, documentation, bug reports, design feedback, and reproducible evaluations are all valuable.
+
+[中文贡献指南](CONTRIBUTING.zh-CN.md)
+
+## Before you start
+
+- Search the [existing issues](https://github.com/diqierjia/StrataGate-AgentMemory/issues) before opening a new one.
+- For a bug, include the relevant integration, Node.js version, reproduction steps, expected behavior, and actual behavior.
+- For a substantial feature or architectural change, open an issue first so the approach and scope can be discussed before implementation.
+- Never include private conversations, credentials, API keys, or other sensitive data in issues, tests, fixtures, or pull requests. Report security issues according to [`SECURITY.md`](SECURITY.md).
+
+By participating, you agree to follow the [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+Useful contributions include:
+
+- fixing a reproducible bug or adding a regression test;
+- clarifying setup, usage, architecture, or evaluation documentation;
+- improving the shared memory engine in `packages/core/`;
+- improving the DeepSeek Harness adapter in `src/`;
+- improving an integration such as `integrations/workbuddy/`;
+- adding a carefully documented benchmark or evaluation;
+- improving accessibility, error messages, or developer experience.
+
+Small, focused changes are welcome. A pull request does not need to introduce a large feature to be useful.
+
+## Development setup
+
+StrataGate is an npm workspace monorepo. Use Node.js `22.19.0` or a newer 22.x release, or Node.js 24 and above. Both Node.js 22 and 24 are tested in CI.
+
+```bash
+git clone https://github.com/diqierjia/StrataGate-AgentMemory.git
+cd StrataGate-AgentMemory
+npm ci
+```
+
+Run the same main checks used by CI:
+
+```bash
+npm run check
+npm test
+npm run build
+```
+
+You can also run a narrower command while iterating:
+
+```bash
+npm run check:core
+npm run test:core
+npm run check:dsh
+npm run test:dsh
+npm run check:workbuddy
+npm run test:workbuddy
+```
+
+## Making a change
+
+1. Create a branch from the latest `main`.
+2. Keep the change focused and avoid unrelated formatting or refactoring.
+3. Add or update tests when behavior changes. A bug fix should ideally include a regression test.
+4. Update the relevant English and Chinese documentation when user-facing behavior changes.
+5. Run the checks that cover your change; run the complete check, test, and build suite before opening a pull request when practical.
+
+Memory behavior is especially sensitive to provenance, timestamps, scope isolation, deterministic ordering, and evidence sufficiency. Changes in these areas should include focused tests for their invariants and edge cases.
+
+## Pull requests
+
+A helpful pull request includes:
+
+- a concise explanation of the problem and the chosen solution;
+- links to relevant issues or discussions;
+- the tests and commands used to verify the change;
+- screenshots or recordings for visible UI changes;
+- documentation updates for changed behavior or configuration;
+- benchmark details and machine-readable artifacts for performance or accuracy claims.
+
+Please keep commits reviewable and respond to review feedback constructively. Maintainers may ask to split a broad pull request into smaller changes.
+
+## Reporting evaluation results
+
+Evaluation claims should be reproducible. Record the dataset or subset, model and configuration, prompts, run count, scoring method, comparison conditions, and relevant artifact hashes. Clearly distinguish complete-system comparisons from component ablations, and avoid generalizing beyond the evaluated scope.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's [MIT License](LICENSE).

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,88 @@
+# 为 StrataGate 做贡献
+
+感谢你帮助改进 StrataGate。代码、测试、文档、问题报告、设计反馈和可复现评测都很有价值。
+
+[English guide](CONTRIBUTING.md)
+
+## 开始之前
+
+- 创建新 Issue 前，请先搜索[已有 Issue](https://github.com/diqierjia/StrataGate-AgentMemory/issues)。
+- 报告问题时，请注明相关集成、Node.js 版本、复现步骤、预期行为和实际行为。
+- 如果准备实现较大的功能或调整架构，请先创建 Issue 讨论方案和范围，再开始开发。
+- 不要在 Issue、测试、fixture 或 Pull Request 中提交私人对话、凭据、API Key 或其他敏感信息。安全问题请按照 [`SECURITY.md`](SECURITY.md) 报告。
+
+参与本项目即表示你同意遵守 [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)。
+
+## 可以贡献什么
+
+以下贡献都很有帮助：
+
+- 修复可复现的问题，或补充回归测试；
+- 完善安装、使用、架构或评测文档；
+- 改进 `packages/core/` 中的共享记忆引擎；
+- 改进 `src/` 中的 DeepSeek Harness 适配层；
+- 改进 `integrations/workbuddy/` 等集成；
+- 增加说明充分、可复现的 benchmark 或评测；
+- 改善无障碍体验、错误提示或开发体验。
+
+我们同样欢迎小而专注的改动。一个 Pull Request 不需要包含大型功能，也可以非常有价值。
+
+## 开发环境
+
+StrataGate 是 npm workspace monorepo。请使用 Node.js `22.19.0` 或更新的 22.x 版本，也可以使用 Node.js 24 及以上版本；CI 会同时使用 Node.js 22 和 24 测试。
+
+```bash
+git clone https://github.com/diqierjia/StrataGate-AgentMemory.git
+cd StrataGate-AgentMemory
+npm ci
+```
+
+运行与 CI 一致的主要检查：
+
+```bash
+npm run check
+npm test
+npm run build
+```
+
+开发过程中也可以只运行相关部分：
+
+```bash
+npm run check:core
+npm run test:core
+npm run check:dsh
+npm run test:dsh
+npm run check:workbuddy
+npm run test:workbuddy
+```
+
+## 修改代码
+
+1. 从最新的 `main` 创建分支。
+2. 保持改动聚焦，避免夹带无关的格式调整或重构。
+3. 行为发生变化时，请增加或更新测试；修复问题时最好补充回归测试。
+4. 面向用户的行为发生变化时，请同步更新相关中英文文档。
+5. 提交 Pull Request 前运行覆盖本次改动的检查；条件允许时，请运行完整的类型检查、测试和构建。
+
+记忆系统尤其依赖来源追溯、时间戳、作用域隔离、确定性排序和证据充分性。修改这些部分时，请为相关不变量和边界情况补充有针对性的测试。
+
+## 提交 Pull Request
+
+一份便于审查的 Pull Request 应包含：
+
+- 对问题和解决方案的简洁说明；
+- 相关 Issue 或讨论的链接；
+- 用于验证改动的测试和命令；
+- 可见界面改动的截图或录屏；
+- 行为或配置变化所需的文档更新；
+- 涉及性能或准确率声明时的评测细节和机器可读产物。
+
+请让提交记录便于审查，并积极回应审查意见。如果 Pull Request 范围过大，维护者可能会建议拆分成多个更小的改动。
+
+## 提交评测结果
+
+评测结论应当可以复现。请记录数据集或子集、模型与配置、提示词、运行次数、评分方法、对比条件和相关产物哈希。请明确区分完整系统对比与单组件消融，并避免把结论推广到未经评测的范围。
+
+## 许可证
+
+提交贡献即表示你同意按本项目的 [MIT License](LICENSE) 授权你的贡献。

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 StrataGate helps long-running AI agents remember across sessions without turning every remembered detail into an unquestioned fact.
 
 [![CI](https://github.com/diqierjia/StrataGate-AgentMemory/actions/workflows/ci.yml/badge.svg)](https://github.com/diqierjia/StrataGate-AgentMemory/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/stratagate-dsh.svg)](https://www.npmjs.com/package/stratagate-dsh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178C6.svg)](https://www.typescriptlang.org/)
 [![Awesome DSH Plugin](https://awesome-dsh-plugin.com/badge.svg)](https://awesome-dsh-plugin.com)
+[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 [中文说明](README.zh-CN.md) · [DeepSeek Harness guide](integrations/deepseek-harness/README.md) · [Architecture](docs/ARCHITECTURE.md) · [Full evaluation](docs/EVALUATION.md)
 
@@ -443,6 +445,12 @@ Choose StrataGate when you want several of these properties together:
 Consider a different plugin first when the user's main requirement is free-form visual editing of memory records, hosted multi-user synchronization across products, or a minimal manually maintained notes file. StrataGate includes a read-oriented knowledge-graph view, but it is optimized for automatic, local, evidence-traceable memory rather than collaborative knowledge-base editing.
 
 For DeepSeek Harness, follow the [quick start](#quick-start-deepseek-harness). The DSH-specific behavior, tools, configuration, and failure semantics are documented in [`integrations/deepseek-harness`](integrations/deepseek-harness).
+
+## Contributing
+
+Contributions are welcome—whether you are fixing a bug, improving documentation, adding an integration, or exploring a better memory and retrieval strategy.
+
+To get started, read [`CONTRIBUTING.md`](CONTRIBUTING.md). It explains how to set up the monorepo, run checks and tests, choose a useful area to work on, and prepare a focused pull request. If you are unsure whether an idea fits the project, [open an issue](https://github.com/diqierjia/StrataGate-AgentMemory/issues) before investing in a large change.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,9 +9,11 @@
 StrataGate 让长期运行的 AI Agent 跨会话记住信息，同时避免把每条记忆都当成不需要核对的事实。
 
 [![CI](https://github.com/diqierjia/StrataGate-AgentMemory/actions/workflows/ci.yml/badge.svg)](https://github.com/diqierjia/StrataGate-AgentMemory/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/stratagate-dsh.svg)](https://www.npmjs.com/package/stratagate-dsh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178C6.svg)](https://www.typescriptlang.org/)
 [![Awesome DSH Plugin](https://awesome-dsh-plugin.com/badge.svg)](https://awesome-dsh-plugin.com)
+[![欢迎贡献](https://img.shields.io/badge/%E6%AC%A2%E8%BF%8E%E8%B4%A1%E7%8C%AE-brightgreen.svg)](CONTRIBUTING.zh-CN.md)
 
 [English](README.md) · [DeepSeek Harness 插件说明](integrations/deepseek-harness/docs/README.zh-CN.md) · [架构说明](docs/ARCHITECTURE.md) · [完整评测](docs/EVALUATION.md)
 
@@ -452,6 +454,12 @@ benchmarks/       机器可读实验结果
 如果你最需要的是自由编辑记忆内容、跨产品的云端多人协作，或者只想维护一个简单的手写便签文件，应先考虑其他插件。StrataGate 已提供以查看和追溯为主的知识图谱界面，但它更适合自动、本地、证据可追溯的 Agent 记忆工作流，而不是多人知识库编辑。
 
 DeepSeek Harness 用户可以从[快速开始](#quick-start-deepseek-harness)安装。DSH 适配层的行为、工具、配置和失败恢复方式见 [DeepSeek Harness 插件中文文档](integrations/deepseek-harness/docs/README.zh-CN.md)。
+
+## 参与贡献
+
+欢迎各种形式的贡献：修复问题、完善文档、增加集成，或探索更好的记忆与检索方案都可以。
+
+请先阅读 [`CONTRIBUTING.zh-CN.md`](CONTRIBUTING.zh-CN.md)，其中包含 monorepo 开发环境、检查与测试命令、适合参与的方向，以及提交 Pull Request 的建议。如果还不确定一个想法是否适合项目，建议先[创建 Issue](https://github.com/diqierjia/StrataGate-AgentMemory/issues)，再投入较大的改动。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

- add dynamic npm and contributions-welcome badges
- add contribution entry points to both READMEs
- add English and Simplified Chinese contribution guides

## Validation

- verified referenced repository files exist
- ran \git diff --check\`n
This PR intentionally contains only the contributor documentation change from commit \7c1ca26\; it excludes the older refactor commits and all uncommitted workspace changes.