### PR TITLE
fix: publish DSH from checked-out source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           node-version: 24.x
           cache: npm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - run: npm ci
       - name: Install complete DSH CLI dependency tree
         run: npm install --no-save --package-lock=false @deepseek-ai/dsh@${{ matrix.dsh }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,5 @@ jobs:
       - run: npm run test:dsh
       - run: npm run build:dsh
       - run: npm run verify:dsh
+        env:
+          DSH_VERSION: ${{ matrix.dsh }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        dsh: [0.1.2-rc.1]
+        dsh: [0.1.2-rc.1, 0.1.5-rc.1]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -40,8 +40,8 @@ jobs:
           node-version: 24.x
           cache: npm
       - run: npm ci
-      - name: Select DSH compatibility target
-        run: npm install --no-save --package-lock=false @deepseek-ai/dsh-agent-default-model@${{ matrix.dsh }} @deepseek-ai/dsh-agent@${{ matrix.dsh }} @deepseek-ai/dsh-attachment@${{ matrix.dsh }} @deepseek-ai/dsh-brand@${{ matrix.dsh }} @deepseek-ai/dsh-client-ui-conversation@${{ matrix.dsh }} @deepseek-ai/dsh-code-runtime@${{ matrix.dsh }} @deepseek-ai/dsh-invariants@${{ matrix.dsh }} @deepseek-ai/dsh-llm@${{ matrix.dsh }} @deepseek-ai/dsh-scope@${{ matrix.dsh }} @deepseek-ai/dsh-session@${{ matrix.dsh }} @deepseek-ai/dsh-settings@${{ matrix.dsh }} @deepseek-ai/dsh-system-prompt@${{ matrix.dsh }} @deepseek-ai/dsh-timeout@${{ matrix.dsh }} @deepseek-ai/dsh-typert-protocol@${{ matrix.dsh }} @deepseek-ai/dsh-user-approval@${{ matrix.dsh }} @deepseek-ai/dsh-tools@${{ matrix.dsh }}
+      - name: Install complete DSH CLI dependency tree
+        run: npm install --no-save --package-lock=false @deepseek-ai/dsh@${{ matrix.dsh }}
       - run: npm run check:dsh
       - run: npm run test:dsh
       - run: npm run build:dsh

--- a/.github/workflows/release-dsh.yml
+++ b/.github/workflows/release-dsh.yml
@@ -6,15 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Exact package version contained in the staged tarball
-        required: true
-        type: string
-      sha256:
-        description: Expected SHA-256 digest of the staged tarball
-        required: true
-        type: string
-      staging_tag:
-        description: Temporary GitHub release tag containing the tarball
+        description: Exact package version committed on main
         required: true
         type: string
 
@@ -24,10 +16,11 @@ permissions:
 
 jobs:
   publish:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -35,66 +28,76 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Install npm with trusted-publishing support
         run: npm install --global npm@^11.15.0
+      - name: Verify release source
+        shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          git fetch origin main --no-tags
+          git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main || {
+            echo "Release commit $GITHUB_SHA is not contained in origin/main"
+            exit 1
+          }
+
+          version="$(node -p 'require("./package.json").version')"
+          tag="stratagate-dsh-v${version}"
+
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            test "$GITHUB_REF_NAME" = "$tag" || {
+              echo "Expected tag $tag, received $GITHUB_REF_NAME"
+              exit 1
+            }
+          else
+            test "$GITHUB_REF" = "refs/heads/main" || {
+              echo "Manual releases must run from main, received $GITHUB_REF"
+              exit 1
+            }
+            test "$REQUESTED_VERSION" = "$version" || {
+              echo "Requested version $REQUESTED_VERSION, but package.json contains $version"
+              exit 1
+            }
+          fi
+
+          test "$(node -p 'require("./package-lock.json").version')" = "$version" || {
+            echo "package-lock.json version does not match package.json"
+            exit 1
+          }
+          test "$(node -p 'require("./package-lock.json").packages[""].version')" = "$version" || {
+            echo "package-lock.json root package version does not match package.json"
+            exit 1
+          }
+
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=$tag" >> "$GITHUB_ENV"
       - run: npm ci
       - run: npm audit --omit=dev --audit-level=high
-      - name: Verify tag and package version match
-        shell: bash
-        run: |
-          expected="stratagate-dsh-v$(node -p 'require("./package.json").version')"
-          test "$GITHUB_REF_NAME" = "$expected" || { echo "Expected tag $expected, received $GITHUB_REF_NAME"; exit 1; }
       - run: npm run check
       - run: npm test
-      - run: npm run verify:dsh
-      - name: Pack release assets from one artifact
+      - name: Build and verify package contents
+        run: |
+          npm run build:dsh
+          node scripts/verify-package.mjs
+      - name: Pack release assets from the checked-out source
         shell: bash
         run: |
-          version="$(node -p 'require("./package.json").version')"
-          versioned="stratagate-dsh-${version}.tgz"
+          versioned="stratagate-dsh-${VERSION}.tgz"
           npm pack --silent
           test -f "$versioned"
+          node scripts/verify-dsh-install.mjs "$versioned"
           cp "$versioned" stratagate-dsh.tgz
           cmp "$versioned" stratagate-dsh.tgz
-          echo "VERSION=$version" >> "$GITHUB_ENV"
+          sha256sum "$versioned" stratagate-dsh.tgz
       - name: Publish exact package artifact
         run: npm publish "stratagate-dsh-${VERSION}.tgz" --provenance --access public
-      - name: Create GitHub release
+      - name: Create GitHub release from pushed tag
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ github.token }}
-        shell: bash
         run: |
-          gh release create "$GITHUB_REF_NAME" "stratagate-dsh-${VERSION}.tgz" stratagate-dsh.tgz --verify-tag --generate-notes --title "StrataGate DSH $VERSION"
-
-  publish-artifact:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ inputs.version }}
-      EXPECTED_SHA256: ${{ inputs.sha256 }}
-      STAGING_TAG: ${{ inputs.staging_tag }}
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-          registry-url: https://registry.npmjs.org
-      - name: Install npm with trusted-publishing support
-        run: npm install --global npm@^11.15.0
-      - name: Download and verify staged package
-        shell: bash
+          gh release create "$RELEASE_TAG" "stratagate-dsh-${VERSION}.tgz" stratagate-dsh.tgz --verify-tag --generate-notes --title "StrataGate DSH $VERSION"
+      - name: Create GitHub release and tag from main
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          filename="stratagate-dsh-${VERSION}.tgz"
-          gh release download "$STAGING_TAG" --repo "$GITHUB_REPOSITORY" --pattern "$filename"
-          echo "${EXPECTED_SHA256}  ${filename}" | sha256sum --check --strict
-          tar -xOf "$filename" package/package.json > package-manifest.json
-          test "$(node -p 'require("./package-manifest.json").name')" = "stratagate-dsh"
-          test "$(node -p 'require("./package-manifest.json").version')" = "$VERSION"
-          cp "$filename" stratagate-dsh.tgz
-          cmp "$filename" stratagate-dsh.tgz
-      - name: Publish exact package artifact
-        run: npm publish "stratagate-dsh-${VERSION}.tgz" --provenance --access public
-      - name: Create GitHub release with verified artifact
-        shell: bash
-        run: |
-          tag="stratagate-dsh-v${VERSION}"
-          filename="stratagate-dsh-${VERSION}.tgz"
-          gh release create "$tag" "$filename" stratagate-dsh.tgz --repo "$GITHUB_REPOSITORY" --target "$GITHUB_SHA" --generate-notes --title "StrataGate DSH $VERSION"
+          gh release create "$RELEASE_TAG" "stratagate-dsh-${VERSION}.tgz" stratagate-dsh.tgz --target "$GITHUB_SHA" --generate-notes --title "StrataGate DSH $VERSION"

--- a/.github/workflows/release-dsh.yml
+++ b/.github/workflows/release-dsh.yml
@@ -26,6 +26,9 @@ jobs:
           node-version: 24.x
           cache: npm
           registry-url: https://registry.npmjs.org
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - name: Install npm with trusted-publishing support
         run: npm install --global npm@^11.15.0
       - name: Verify release source

--- a/.github/workflows/release-dsh.yml
+++ b/.github/workflows/release-dsh.yml
@@ -81,12 +81,21 @@ jobs:
         shell: bash
         run: |
           versioned="stratagate-dsh-${VERSION}.tgz"
+          source_asset="stratagate-dsh-${VERSION}-source.tar.gz"
           npm pack --silent
           test -f "$versioned"
           node scripts/verify-dsh-install.mjs "$versioned"
+          git archive --format=tar.gz --prefix="stratagate-dsh-${VERSION}/" --output="$source_asset" "$GITHUB_SHA"
+          test -f "$source_asset"
+          source_root="stratagate-dsh-${VERSION}"
+          tar -xOf "$source_asset" "$source_root/package.json" > source-package.json
+          test "$(node -p 'require("./source-package.json").name')" = "stratagate-dsh"
+          test "$(node -p 'require("./source-package.json").version')" = "$VERSION"
+          rm -f source-package.json
           cp "$versioned" stratagate-dsh.tgz
           cmp "$versioned" stratagate-dsh.tgz
-          sha256sum "$versioned" stratagate-dsh.tgz
+          sha256sum "$versioned" stratagate-dsh.tgz "$source_asset"
+          echo "SOURCE_ASSET=$source_asset" >> "$GITHUB_ENV"
       - name: Publish exact package artifact
         run: npm publish "stratagate-dsh-${VERSION}.tgz" --provenance --access public
       - name: Create GitHub release from pushed tag
@@ -94,10 +103,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$RELEASE_TAG" "stratagate-dsh-${VERSION}.tgz" stratagate-dsh.tgz --verify-tag --generate-notes --title "StrataGate DSH $VERSION"
+          gh release create "$RELEASE_TAG" "stratagate-dsh-${VERSION}.tgz" stratagate-dsh.tgz "$SOURCE_ASSET" --verify-tag --generate-notes --title "StrataGate DSH $VERSION"
       - name: Create GitHub release and tag from main
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$RELEASE_TAG" "stratagate-dsh-${VERSION}.tgz" stratagate-dsh.tgz --target "$GITHUB_SHA" --generate-notes --title "StrataGate DSH $VERSION"
+          gh release create "$RELEASE_TAG" "stratagate-dsh-${VERSION}.tgz" stratagate-dsh.tgz "$SOURCE_ASSET" --target "$GITHUB_SHA" --generate-notes --title "StrataGate DSH $VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,44 @@
 # Changelog
 
-## Unreleased
+## 0.2.64 - 2026-09-12
 
+- Separate read-only status refresh from targeted retries for Block Summary, Event extraction, and Graph projection failures. The status page now lists every failed job with Block and conversation context, attempt count, retry time, latest error, visible progress, and durable retry failure feedback.
 - Render short-term Block status only in the corresponding turn's content flow, so it scrolls with the conversation instead of staying beside the composer. Add a persistent Advanced Settings switch that hides this status without disabling memory capture or processing.
 
 - Run folded-turn ingestion on a count-triggered, per-session background drain so the agent hot path does not wait for memory processing; failed and unprocessed turns are restored in order for a later retry or explicit flush.
 - Keep automatic long-term-memory retrieval keyed to the current user message, avoiding stale previous-topic context during consecutive conversations.
 - Safely omit `reasoningEffort` when model capability lookup fails or times out, and emit at most one fallback warning for each provider/model route.
 - Expose the `structuredReasoningEffort` policy (`auto` or `force-off`) as a user-editable plugin setting; unsupported `force-off` requests fall back to the model default instead of failing the structured call.
+## 0.2.63 - 2026-09-12
+
+- Make DSH core packages host-provided optional peers instead of profile-local plugin dependencies. The new `stratagate-dsh-repair` command moves old hoisted DSH peers into a recoverable profile backup before startup; a bootstrap resolver then forces StrataGate's own imports through DSH's installation-owned fallback, and unsupported host families fail fast with a diagnostic.
+- Add a safe bridge for v0 sessions containing the retired `stratagate/memory-citations` event. The original generation remains untouched and a recovery receipt records both hashes.
+- Formally test the complete DSH `0.1.2-rc.1` family and DSH `0.1.5-rc.1` with its real `0.1.5-rc.2` internal dependency tree.
+
+## 0.2.60 - 2026-09-08
+
+- Queue folded turns on a count-triggered, per-session background drain with bounded retry backoff; failed batches are restored in order and a later explicit flush can recover them without losing memory.
+- Keep automatic long-term-memory retrieval keyed to the current user message, avoiding stale previous-topic snapshots during consecutive conversations.
+- Expose the structured reasoning-effort policy through DSH settings; capability lookup failures now conservatively omit `reasoningEffort`, and each provider/model route emits at most one fallback warning.
+- Migrate the Web client from the removed `conversationEvents` service to `uiConversation.events`, adopt the new Session snapshot and branded-sequence APIs, and update the supported DSH baseline to `0.1.2-rc.1`.
+
+## 0.2.59 - 2026-09-08
+
+- Increase the structured model task timeout from 45 to 120 seconds so Event extraction has enough time to complete on slower model responses.
+
+## 0.2.58 - 2026-09-08
+
+- Style normal background memory processing with the blue informational theme, reserving red danger styling for failures.
+
+## 0.2.57 - 2026-09-07
+
+- Add an explicit per-Block Summary retry action for terminal failures, with affected conversation details and separate status refresh behavior.
+- Give a user-requested retry a fresh bounded attempt budget while preserving raw conversation data and continuing downstream Event and graph processing only after Summary succeeds.
+
+## 0.2.56 - 2026-09-07
+
+- Include Block Summary failures in workspace alerts, diagnostics, and system status instead of reporting only downstream Event and graph jobs.
+- Derive pending Block presentation from the persisted Summary job and use workspace-wide job totals on the system page.
 
 ## 0.2.55 - 2026-09-07
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -6,6 +6,7 @@
       inject: [tools, systemPrompt, llm, agentDefaultModel]
       config:
         database: !!js dshHomePath('stratagate', 'memory.db')
+        sessionRoot: !!js dshHomePath('sessions')
         namespaceMode: project
         blockTurnSize: 6
         blockDecayLambda: 0.3

--- a/docs/DSH.md
+++ b/docs/DSH.md
@@ -14,8 +14,6 @@ The plugin adapts DSH session events to the existing StrataGate memory engine; i
 
 ### Layered short-term memory
 
-Block status appears only below the corresponding answer and scrolls with the conversation at the same content level. It is never pinned beside the composer, and the home screen and empty new conversations cannot inherit the previous conversation's status. To hide these rows without changing memory capture or processing, turn off **Show short-term memory status in chat** under **More → Advanced Settings**.
-
 ![StrataGate layered short-term memory view](assets/stratagate-short-term-memory.png)
 
 ## How it is designed
@@ -149,6 +147,7 @@ config:
   blockDecayLambda: 0.3
   ingestSubagents: false
   maxOutputTokens: 10000
+  structuredTaskTimeoutMs: 120000
   structuredReasoningEffort: auto # auto | force-off
   # Optional: use a dedicated model for memory processing.
   # provider: deepseek
@@ -173,7 +172,9 @@ For diagnostics, the five most recent successful memory-model responses are reta
 
 ## Compatibility and permissions
 
-Release gates exercise DSH `0.1.2-rc.1` on Node `24`, plus the core package on Node `22.19` and `24`. The published peer range accepts compatible DSH releases from `0.1.2-rc.1` up to, but not including, `0.2.0`.
+Release gates exercise the complete DSH `0.1.2-rc.1` family and `@deepseek-ai/dsh@0.1.5-rc.1` on Node `24`, on both Linux and Windows. The latter's real dependency tree resolves its internal DSH packages to `0.1.5-rc.2`; that is intentional. The plugin declares these DSH packages as optional, exact-version peers so the host supplies one coherent runtime instead of npm installing a second copy. Other `0.1.x` versions are not implicitly supported.
+
+DSH core packages are host-provided optional peers. After upgrading a profile that once installed those peers locally, run `dsh plugin --profile <name> exec stratagate-dsh-repair` before starting it. The command moves only the known DSH runtime packages into `.stratagate-runtime-backups` inside that profile and writes a recovery receipt; it does not delete them or touch session data. At startup, a bootstrap resolver also forces StrataGate's own imports through the installation-owned module fallback, then verifies the resolved DSH core family and stops with an actionable error for an unknown host family. On DSH `0.1.5`, v0 sessions containing the retired `stratagate/memory-citations` event are copied to a validated v1 generation before the host migrates them to v3. The original v0 log is never modified; a `stratagate-legacy-citations-v1.json` receipt records source/target hashes and recovery instructions.
 
 The package declares local filesystem read/write and Harness tool registration. It does not request direct network, subprocess, shell, Python, or credential access. Model calls still flow through DSH's existing LLM service.
 

--- a/docs/DSH.zh-CN.md
+++ b/docs/DSH.zh-CN.md
@@ -14,8 +14,6 @@
 
 ### 分层短期记忆
 
-记忆块状态只显示在对应回答下方，与聊天内容处于同一层级并随对话一起滚动，不再固定在输入框旁；首页和空白新对话也不会继承上一段对话的状态。如需隐藏这些状态行，可在 **更多 → 高级设置** 中关闭 **聊天中显示短期记忆状态**，记忆采集和处理不会受到影响。
-
 ![StrataGate 分层短期记忆界面](assets/stratagate-short-term-memory.png)
 
 ## 它是怎么设计的
@@ -146,6 +144,7 @@ config:
   blockDecayLambda: 0.3
   ingestSubagents: false
   maxOutputTokens: 10000
+  structuredTaskTimeoutMs: 120000
   structuredReasoningEffort: auto # auto | force-off
   # 可选：为记忆处理指定专用模型。
   # provider: deepseek
@@ -170,7 +169,9 @@ config:
 
 ## 兼容性与权限
 
-发布门禁会在 Node `24` 上测试 DSH `0.1.2-rc.1`，并在 Node `22.19` 和 `24` 上测试核心包。发布包声明的 peer 版本范围接受从 `0.1.2-rc.1` 开始、低于 `0.2.0` 的兼容 DSH 版本。
+发布门禁会在 Node `24`、Linux 和 Windows 上测试完整的 DSH `0.1.2-rc.1` 依赖族，以及 `@deepseek-ai/dsh@0.1.5-rc.1`。后者的真实依赖树会把内部 DSH 包解析为 `0.1.5-rc.2`，这是预期行为。插件将这些 DSH 包声明为可选且精确版本的 peer，由宿主提供一套一致的运行时，避免 npm 在插件目录再安装第二套核心包；不会笼统承诺其他 `0.1.x` 版本。
+
+DSH 核心包现在都是由宿主提供的可选 peer。若某个 profile 曾在本地安装这些 peer，升级后、启动前运行 `dsh plugin --profile <名称> exec stratagate-dsh-repair`。该命令只会把已知 DSH 运行时包移动到 profile 内的 `.stratagate-runtime-backups` 并写入恢复收据，不会删除包或触碰会话数据。启动时 bootstrap 还会把 StrataGate 自身的 DSH 导入定向到宿主维护的共享模块回退目录，再检查实际解析出的 DSH 核心族；未知宿主会立即给出明确错误并停止，而不是让正文区域空白。对于 DSH `0.1.5`，含已废弃 `stratagate/memory-citations` 事件的 v0 会话会先复制成经过校验的 v1 代际，再交给宿主迁移到 v3；原始 v0 日志不会被修改，并写入 `stratagate-legacy-citations-v1.json` 记录源/目标哈希和恢复说明。
 
 该包申请本地文件系统读写权限和 Harness 工具注册权限，不申请直接网络访问、子进程、Shell、Python 或凭证访问权限。模型调用仍通过 DSH 现有的 LLM 服务进行。
 

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,10 +1,13 @@
 {
   "name": "stratagate-dsh",
-  "version": "0.2.55",
+  "version": "0.2.64",
   "description": "Recent conversations stay vivid. Older ones fade into summaries, not oblivion. StrataGate gives DeepSeek Harness six-layer, time-decaying memory, while lasting events and relationships settle into a knowledge graph. Bring your memories from other AIs with you—no need to start over.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "stratagate-dsh-repair": "./dist/repair-profile.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -55,7 +58,7 @@
     "test:dsh": "vitest run --config vitest.config.ts",
     "test:core": "npm run test --workspace @diqier/stratagate",
     "test:workbuddy": "npm run test --workspace stratagate-workbuddy",
-    "verify:dsh": "npm run build:dsh && node scripts/verify-package.mjs",
+    "verify:dsh": "npm run build:dsh && node scripts/verify-package.mjs && npm pack --ignore-scripts --pack-destination . && node scripts/verify-dsh-install.mjs stratagate-dsh-0.2.64.tgz",
     "verify:workbuddy": "npm run verify:package --workspace stratagate-workbuddy",
     "test:watch": "vitest --config vitest.config.ts",
     "prepare": "npm run build:dsh"
@@ -111,7 +114,8 @@
     },
     "compatibility": {
       "dshVersions": [
-        "0.1.2-rc.1"
+        "0.1.2-rc.1",
+        "0.1.5-rc.1"
       ]
     },
     "permissions": [
@@ -144,26 +148,47 @@
     "node": "^22.19.0 || >=24.0.0"
   },
   "peerDependencies": {
-    "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-agent-default-model": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-client-ui-conversation": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-llm": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-session": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-settings": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-system-prompt": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-tools": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/schemastery": "^3.18.1"
+    "@deepseek-ai/cordis": "4.0.2",
+    "@deepseek-ai/dsh-agent-default-model": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-client-ui-conversation": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-llm": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-session": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format-catalog": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format-v0-to-v1": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-settings": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-tools": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/schemastery": "3.18.2"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/cordis": { "optional": true },
+    "@deepseek-ai/dsh-agent-default-model": { "optional": true },
+    "@deepseek-ai/dsh-client-ui-conversation": { "optional": true },
+    "@deepseek-ai/dsh-llm": { "optional": true },
+    "@deepseek-ai/dsh-session": { "optional": true },
+    "@deepseek-ai/dsh-session-format": { "optional": true },
+    "@deepseek-ai/dsh-session-format-catalog": { "optional": true },
+    "@deepseek-ai/dsh-session-format-v0-to-v1": { "optional": true },
+    "@deepseek-ai/dsh-settings": { "optional": true },
+    "@deepseek-ai/dsh-system-prompt": { "optional": true },
+    "@deepseek-ai/dsh-tools": { "optional": true },
+    "@deepseek-ai/schemastery": { "optional": true }
   },
   "devDependencies": {
-    "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-agent-default-model": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-client-ui-conversation": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-llm": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-session": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-settings": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-tools": "0.1.2-rc.1",
-    "@deepseek-ai/schemastery": "^3.18.1",
+    "@deepseek-ai/cordis": "4.0.2",
+    "@deepseek-ai/dsh": "0.1.5-rc.1",
+    "@deepseek-ai/dsh-agent-default-model": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-client-ui-conversation": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-llm": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format-catalog": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format-v0-to-v1": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-settings": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-system-prompt": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-tools": "0.1.5-rc.2",
+    "@deepseek-ai/schemastery": "3.18.2",
     "@types/node": "^22.0.0",
     "cytoscape": "^3.34.1",
     "cytoscape-fcose": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "stratagate-dsh",
-  "version": "0.2.55",
+  "version": "0.2.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stratagate-dsh",
-      "version": "0.2.55",
+      "version": "0.2.64",
       "license": "MIT",
+      "bin": {
+        "stratagate-dsh-repair": "dist/repair-profile.js"
+      },
       "workspaces": [
         "packages/*",
         "integrations/workbuddy"
@@ -17,15 +20,19 @@
         "ngraph.leiden": "^0.3.0"
       },
       "devDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-default-model": "0.1.2-rc.1",
-        "@deepseek-ai/dsh-client-ui-conversation": "0.1.2-rc.1",
-        "@deepseek-ai/dsh-llm": "0.1.2-rc.1",
-        "@deepseek-ai/dsh-session": "0.1.2-rc.1",
-        "@deepseek-ai/dsh-settings": "0.1.2-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
-        "@deepseek-ai/dsh-tools": "0.1.2-rc.1",
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/cordis": "4.0.2",
+        "@deepseek-ai/dsh": "0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-default-model": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-catalog": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v0-to-v1": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "3.18.2",
         "@types/node": "^22.0.0",
         "cytoscape": "^3.34.1",
         "cytoscape-fcose": "^2.2.0",
@@ -38,15 +45,56 @@
         "node": "^22.19.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-default-model": ">=0.1.2-rc.1 <0.2.0",
-        "@deepseek-ai/dsh-client-ui-conversation": ">=0.1.2-rc.1 <0.2.0",
-        "@deepseek-ai/dsh-llm": ">=0.1.2-rc.1 <0.2.0",
-        "@deepseek-ai/dsh-session": ">=0.1.2-rc.1 <0.2.0",
-        "@deepseek-ai/dsh-settings": ">=0.1.2-rc.1 <0.2.0",
-        "@deepseek-ai/dsh-system-prompt": ">=0.1.2-rc.1 <0.2.0",
-        "@deepseek-ai/dsh-tools": ">=0.1.2-rc.1 <0.2.0",
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/cordis": "4.0.2",
+        "@deepseek-ai/dsh-agent-default-model": "0.1.2-rc.1 || 0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "0.1.2-rc.1 || 0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "0.1.2-rc.1 || 0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "0.1.2-rc.1 || 0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-catalog": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v0-to-v1": "0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "0.1.2-rc.1 || 0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1 || 0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "0.1.2-rc.1 || 0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "3.18.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-agent-default-model": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-client-ui-conversation": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-llm": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-format": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-format-catalog": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-format-v0-to-v1": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-settings": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-system-prompt": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-tools": {
+          "optional": true
+        },
+        "@deepseek-ai/schemastery": {
+          "optional": true
+        }
       }
     },
     "integrations/workbuddy": {
@@ -70,11 +118,544 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
+      "integrity": "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.978.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.978.0.tgz",
+      "integrity": "sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.71.tgz",
+      "integrity": "sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.73.tgz",
+      "integrity": "sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.16.tgz",
+      "integrity": "sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/credential-provider-env": "^3.972.71",
+        "@aws-sdk/credential-provider-http": "^3.972.73",
+        "@aws-sdk/credential-provider-login": "^3.972.78",
+        "@aws-sdk/credential-provider-process": "^3.972.71",
+        "@aws-sdk/credential-provider-sso": "^3.973.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.78.tgz",
+      "integrity": "sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.83",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.83.tgz",
+      "integrity": "sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.71",
+        "@aws-sdk/credential-provider-http": "^3.972.73",
+        "@aws-sdk/credential-provider-ini": "^3.973.16",
+        "@aws-sdk/credential-provider-process": "^3.972.71",
+        "@aws-sdk/credential-provider-sso": "^3.973.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.71.tgz",
+      "integrity": "sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.15.tgz",
+      "integrity": "sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/token-providers": "3.1129.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1129.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1129.0.tgz",
+      "integrity": "sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.77.tgz",
+      "integrity": "sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.53.tgz",
+      "integrity": "sha512-bIrDaMENQmYRBHntOiOheqkiw5+fhKW4Lqb+mS1uqF0VwvdWI22fW2HFgWrng66CmYd+4k8ePlpj38sEfTuMLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.45.tgz",
+      "integrity": "sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@deepseek-ai/cordis": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.2.tgz",
       "integrity": "sha512-asOnXP1TzFSFQlHb1iegDZp0z/8WD1c7YNrwJR/Tx2bzNuMXfcekE/I67Iv6SQXeLB4csxqCngzQKANP7gdw0g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.3",
@@ -96,35 +677,340 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/cosmokit": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.3.tgz",
-      "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-rc.1.tgz",
-      "integrity": "sha512-lfaqN34vUCWvbn1kJVHrhfJ6Dvt1HDHCm33ZCpmKkl07/5q6FxWqVv6rOdVX5QnM/9xz/uYiN0nQwUtBg4+Skg==",
+    "node_modules/@deepseek-ai/cordis-plugin-group": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-group/-/cordis-plugin-group-1.0.2.tgz",
+      "integrity": "sha512-OeGiPD793Mhma9+rGIox95neuufwOFTqQ5jooFgrMK/Mn7Fp7Hkv/d7VKMXZz40iks2fZCbiFE6p9WjTVTQRdg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-session-projection": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1"
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-hmr": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-hmr/-/cordis-plugin-hmr-1.0.17.tgz",
+      "integrity": "sha512-o1BooaJpwd+C80Tn5+B48MGqrfNZydlfRVQjmCrrULA4nCmlMqBKjDF2FmcZoNP+L2uX9m/6DdGKVtFpQRQVUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^4.0.3",
+        "picomatch": "^4.0.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-include": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.7.tgz",
+      "integrity": "sha512-bZ4S1YuOmwOeE97HnslQ6ggVQbaWz4GejJ8OcY4P/DIyc1Qhu/3Szt1XSw6c/pd37kRkxxJXGwt4cmCxWSBBuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3",
+        "js-yaml": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-loader": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.3.tgz",
+      "integrity": "sha512-YNcHiH7TRFrgnRbQU7qdS1spABUFFHg04QpB9DdboPEjgKLTFfeEAvr6Y7qll3/nGgqywDQdk1tYshqKO0p1WQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "node-addon-require-builtin": "^0.1.4"
+      },
+      "peerDependenciesMeta": {
+        "node-addon-require-builtin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cordis-plugin-timer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-timer/-/cordis-plugin-timer-1.1.4.tgz",
+      "integrity": "sha512-GhxOiU+TF2BbNBKlV2N24zvfv2Kh7RxkFW1hjML6s+DOb+y2zomzbeC5zHIIjsc/rpRwbKpDNucPGSwkH0ChXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/cosmokit": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.3.tgz",
+      "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh": {
+      "version": "0.1.5-rc.1",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh/-/dsh-0.1.5-rc.1.tgz",
+      "integrity": "sha512-rmNmzQCg3oIc1z8xH7izRSOuy1TNzq+/NILyfM+7e8DKOyV+yBtg47WEsqR2SiIe1ATec3L/rUa1YhIcfQ2XEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-acp-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-agent-tool-presentation": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-app-boot": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-base": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-compact": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-command-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-fs-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-headless": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-hooks-claude-code": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-hooks-codex": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-http-proxy": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-persona": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-schedule": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sdk-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-sdk-minimal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-session-reference": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-time-context": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tmux-context": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-ask-user": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-cordis": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-present": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-str-replace-editor": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-web": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-web-app": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-webhook": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-webhook-github": "^0.1.5-rc.1",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.5-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0",
+        "js-yaml": "^4.2.0",
+        "node-addon-require-builtin": "^0.1.4"
+      },
+      "bin": {
+        "dsh": "lib/bin.js"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp/-/dsh-acp-0.1.5-rc.2.tgz",
+      "integrity": "sha512-0lmDF2qyy136fTFN7jowBVBRVQ00YASi1umgnFSVpHQ0rDKh32tpl7xWaoOTlh6mmKh04A93qt92QhPLIzkcSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "1.4.0",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-mcp-client": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-token-meter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp-app": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-acp-app/-/dsh-acp-app-0.1.5-rc.2.tgz",
+      "integrity": "sha512-90SRAmF6haHARulVllv6uh88n+zubdrgDfxvTzmi9+p3ktt7o6oZ6+yKO7I7e04bSskT+Pz/1J0FLugi9l39dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-acp": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.2",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-acp-app/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.5-rc.2.tgz",
+      "integrity": "sha512-SlUL1riZmVLwMUR3jo9CP/R1cxov9dHkCJDh6JQW3fSZJVCIdPygBRlAweCUDvHxAEmPpFHxE/U3NmSUbX+vQQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.2-rc.1.tgz",
-      "integrity": "sha512-feuTXXl6jIAp71O77l8XzeKcpgahlCXQ7YUjM+Cl/VF0EBpctKkdvwbvTalImRzYYzX5qGK74hblsT2HC4xEwQ==",
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.5-rc.2.tgz",
+      "integrity": "sha512-B2e3e1iT+iSE2Pf7bnrKmsbOPiD+ZXplVhL98K35y0IGX7yUdqATsyKVPEHjgfCGooNKjGlSBB42kUk3s7Iv/A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-instructions": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-instructions/-/dsh-agent-instructions-0.1.5-rc.2.tgz",
+      "integrity": "sha512-735wmeuRDr/fB9vCnBALEHE7z04Lmhx6WX3KJLE3DjWMGbmTudU5i0iYSYst2mZh7C/igV5wXBveIGKLPIrL+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-loop": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-loop/-/dsh-agent-loop-0.1.5-rc.2.tgz",
+      "integrity": "sha512-24wvqVlqFmdqJ2Bhcku/vKeNy+qWSmeEeN7lvcUB+WkhcF0/Ra2G3WwcVmnahJA4+w0AKdW3W7v+YYcO/jKJpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-presets": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.5-rc.2.tgz",
+      "integrity": "sha512-h0j7IfuHPYh/oJR7SDxh6pzSgUeaHwaaAIg5X0RNL6Z2oQrq0oUmjtArCVVw7nkgt48DjdBwx4EwJ9IdNrHxug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "js-yaml": "^4.1.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-agent-tool-presentation": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-tool-presentation/-/dsh-agent-tool-presentation-0.1.5-rc.2.tgz",
+      "integrity": "sha512-XA4Z3zm73SQw4VmWdo2Z/HdRr3YCWL7SseO70wIuYbcjfar1BdMC0S6/KXTgvshn1lCuCqf7I47B1e5oxoHKhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -132,15 +1018,533 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-settings": "^0.1.2-rc.1"
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-anonymous-user-id": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-anonymous-user-id/-/dsh-anonymous-user-id-0.1.5-rc.2.tgz",
+      "integrity": "sha512-YIpZoi8mY/d+BjnPOryDYR7lkwr2uWh5KJWjIqm2sGN+C6imc66lDiSi5wy91JMRzefFWJf26fCiYXAF7ErQAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-gateway": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.5-rc.2.tgz",
+      "integrity": "sha512-jYDsxVyRnRI++f+hXqBJemOk6ASTvly1sO8ZRuoI77RR22r0nfTFiifxevbmUcavl6j9fgB/LL3X7BpXMy5QQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "ws": "^8.21.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-remotes": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.5-rc.2.tgz",
+      "integrity": "sha512-O8t/aJiHatgzlQIgXx6xdmpy+iAXJ/Zab1xMHIx7Noo6mzSYUIxwfJkoYgPv9G0Yfx06FPoRTUtLiZ8IADqUOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-session-controller": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-session-controller/-/dsh-api-session-controller-0.1.5-rc.2.tgz",
+      "integrity": "sha512-rwOxS6piZ9EuLgE/pbq4cUlRCGv98IKgdFnK5v8WNwZYKug3rUpvYODDU9vE42ydmClgjFd/KIAaEDFPatcDpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "mime-types": "^3.0.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-file-upload": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-file-reference": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-native-command": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-query": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-time": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-workspace-path": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-workspace": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-jobs": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-settings-controller": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-settings-controller/-/dsh-api-settings-controller-0.1.5-rc.2.tgz",
+      "integrity": "sha512-HcnffXfBLi8Xaq3i8DZDDMZHkekW3RjRvA1XqnG/1SLR2w9OEt5P3oY2VzO0UuhyBlYCjS61BwGxDa5zWLCPlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-native-command": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-workspace-controller": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-controller/-/dsh-api-workspace-controller-0.1.5-rc.2.tgz",
+      "integrity": "sha512-95USICv+Ds+BS4Bjf27gVneXc/ZuhlYvTsdfjx/S+MMSutjgV2eZDKkQOxVn8u8KMZw3FG0X5Era47qa3kg01Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-workspace": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-api-workspace-files": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-workspace-files/-/dsh-api-workspace-files-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Kx4ksBWQhN2Sbj48TPwC9cM0cxltIKzjyzanYog0d1WRnzxtqPDHthi6fx1I6RYA+k6257/xLi/Vx/ThYJ1ppQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-deque": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-app-boot": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-app-boot/-/dsh-app-boot-0.1.5-rc.2.tgz",
+      "integrity": "sha512-beM+ULhjr2mGoyrWta3F6HOQ9OD+i5tKG8BU0RtgVGmXDjA57cVEAiEkkgPLMTxbbzU+xsFP61I5SApna4Cz5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-package-manifest": "^0.1.5-rc.2",
+        "js-yaml": "^4.2.0",
+        "resolve.exports": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-group": "^1.0.2",
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/cordis-plugin-hmr": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-atomic-write": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.5-rc.2.tgz",
+      "integrity": "sha512-9bCOLkug83IGuoEBPHUxgfJ/IxsHg/UigGi8Oj0agibcGVq2WdL/fbU8KA3KU5H49KDOxq2/AA3XUI3RiAEtYA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-attachment": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.5-rc.2.tgz",
+      "integrity": "sha512-S6b8/WjqzGw+dMDLRXnq+tbijDGkQh38yE+zpQytX2/w/mPR3VzGj5r6McS01WwD76vXR8WFoheSCLyCAro8WQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-attachment-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment-local/-/dsh-attachment-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-UN9Zw6oBqHl/SQxFQCGUp8OcARQkPzZo4BGNkSQHqSsEo3d59Mv7H5mSFHmKl4NogSMwksjN3SF0FocN7xyF2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "sharp": "^0.35.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-authorization": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-authorization/-/dsh-authorization-0.1.5-rc.2.tgz",
+      "integrity": "sha512-1AtUlo72eYUwiiYL728E4oLgGfP3Kq1yiftiKv0hZ9AYzwZRMIGxv1659UymViNQ/m3BIEPlfiv+vWIDHkqMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-base": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-base/-/dsh-base-0.1.5-rc.2.tgz",
+      "integrity": "sha512-a4QqqqnN/qmWmIvFdCsXXlPerI3IhyIXh0UdLX1Wo1Q6P+blCIkQDG4LLLNS4RoWjhDURoKm2t51NBjotD6BVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis-plugin-hmr": "^1.0.17",
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-instructions": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-api-gateway": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-attachment-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-bash-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-command-compact": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-command-goal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-compaction-basic": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-credentials-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs-observation-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-goal-round-driver": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm-pi-ai": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-plan-mode": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-plugin-package-inventory-deepseek": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-pwsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-repeat-tool-reminder": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-checkpoint-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-log-deepseek": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-query-sqlite": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-telemetry-otel": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title-first-prompt-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings-file": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell-env": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-skill-badge": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-skill-filesystem": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-spill-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-spill-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-storage": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-storage-json": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent-fork-in-process": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent-spawn-in-process": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-bash": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-call-timeout-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-fs-search": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-goal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-present": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-pwsh": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-ralph": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-skill": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-subagent-control": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-web": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-workflow": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-loader": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-questions": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-web": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-web-fetch-http": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-web-search-deepseek": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-workflow-worker-thread": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-bash-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-local/-/dsh-bash-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-a/FTpYUKY0Sorn4GlY2HjuQh7+gjU8XQ2+HRDN0tuqMQyO1RIzJi62FjtZSZ6+qV4EJJ8o8h0+8URHsVrzro+Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-bash-sandbox": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-bash-sandbox/-/dsh-bash-sandbox-0.1.5-rc.2.tgz",
+      "integrity": "sha512-y8vwK6jf4gPq8mG71zWure803NjfqJ66Nvzr1FTB8An+IF68hT2eU+hHJCByvP0u6FuiLPRptuX/im2CxcNo1g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-bash-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-rc.1.tgz",
-      "integrity": "sha512-y2RHIag3kzLdY8kTBuSUSTsKzWPscJrysNObXTiNM7stXLpa3jXpshsB1caqGzNx50vYcmHeN1gFVECgx3NZHg==",
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.5-rc.2.tgz",
+      "integrity": "sha512-/+3TzQRYT4M8NINZ9OrsL5VWNyQSXof8mFLx3txiosWA7Bt0H6UcxUdKGXVwj6gCXhsQ74mzEHm2ucsflG0mYA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-chunked-list": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-chunked-list/-/dsh-chunked-list-0.1.5-rc.2.tgz",
+      "integrity": "sha512-XPr311bleMyOh9SzhTMmc1mC6qx2Tty8315MNYYyzIOLAns0h27PReFa9axy8I0soBaE7gfp6eQI1ZriVkI68g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-connection": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.5-rc.2.tgz",
+      "integrity": "sha512-W0GAZX01hAfrfjoZbtwEJ5ik3dG20Hy/0TFYJ6dnvwxtcacGYNIwi3f2oHpZgLcEw+PWwq1Y9IV1iKG+yDOytg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-file-upload": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-file-upload/-/dsh-client-file-upload-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Y0v4pr1btn1fY8ox1cxIuxDhm2RKHrztfIDMhzj2Z1xRCdSdfbZYtkYvOdWS4uAbpZWQKs5gDMGgASvwTCJ+lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-hmr": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-hmr/-/dsh-client-hmr-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Ra1JziRbpV5CiIaYUT4FbBKko1m+PONCGJjmKM7PyHSAv00v53/xKREHVB1SNqu/QT9cGs688ID2KHuwFxbHSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-locale": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-locale/-/dsh-client-locale-0.1.5-rc.2.tgz",
+      "integrity": "sha512-kv56ki/WQWagsHt94wJAPzsiKnxa8KlmM33bZGgl2SgF4atlQ3iRCdkwJ3fQARXF4Ocnfutivoj5fu5usks1Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-modules": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-modules/-/dsh-client-modules-0.1.5-rc.2.tgz",
+      "integrity": "sha512-034DxLlGvX4GgkqqFN2SGcQx8hKdicj5IrgENclBXXbyMDlpF9xADiWi5DxPms+iOBcL/5LLe84q/GCTWOrA2g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-resources": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-resources/-/dsh-client-resources-0.1.5-rc.2.tgz",
+      "integrity": "sha512-fl0saN8LKcAZ/YUSqxBeAbzVj6ZSBWnWrKGFUqhuq5N0XHWu4CpswFIruKxkvgl7lwAsdTtbL3wMtsKIupSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-agent-preset": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-agent-preset/-/dsh-client-ui-agent-preset-0.1.5-rc.2.tgz",
+      "integrity": "sha512-BMhRU54q7/8E/JoksXm9TW1rCBBg2V64XsDwltYWmCLcZuLCVBc3GX7t/11WMERNi8Do+0ZM6khslwrhbT5QLw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-approval": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-approval/-/dsh-client-ui-approval-0.1.5-rc.2.tgz",
+      "integrity": "sha512-jrlEBEYfYq04HuKYBxD1yI5Z9btJ4fnuWbz3xtK8M/gvsTye8PrhCMxaNARMznGiUFoXmwv9CRhl/KAqbbfE/g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-attachment": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-attachment/-/dsh-client-ui-attachment-0.1.5-rc.2.tgz",
+      "integrity": "sha512-+i98BXfTpz9HX0G7m7k9ka1R5Tekd0tBIljFtKMmiXWju5MW1u+dngpmGCwoSHenEuZGZDC8K/qgw7MIOcbRnw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-brand-official": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-brand-official/-/dsh-client-ui-brand-official-0.1.5-rc.2.tgz",
+      "integrity": "sha512-VESOQ7N8MmUNyy5H1A099Zx3NW1DTTcFIdN/zYVTXWKukmSR6xanShJMai6e69ibDmUfh0YmRgwOvHOVd2K0Uw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-chat": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-chat/-/dsh-client-ui-chat-0.1.5-rc.2.tgz",
+      "integrity": "sha512-ywvtoJUgd/vkfETuFDIgqrvdR5yzfvBDqpuyw0pFDHaHwLzRtk/xPjraI9blNoLWQ8x/Sp42aS4Pr7XQPfjIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-commands": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-commands/-/dsh-client-ui-commands-0.1.5-rc.2.tgz",
+      "integrity": "sha512-wXSTOM4DHogdXZp8tp5RhEvpRJbNey/lN7yjCNN5Qg+BjSu6BAVwKLRKiriCmKIKJcEEpq4BFQb9Di4c1GMm1w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -148,42 +1552,976 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-client-ui-conversation": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.2-rc.1.tgz",
-      "integrity": "sha512-PDrV7twPfmZE5TjdvdVVZMHOla36wCojRC8GJBUp1cdXsWUP+Omk10gxYbH1g5TQPdAWgSL+GktdjondSXMSNQ==",
-      "dev": true,
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-conversation/-/dsh-client-ui-conversation-0.1.5-rc.2.tgz",
+      "integrity": "sha512-VnZ0VrmI7+1JH/iMYV6+FaxCsZrVk4CZIuG+k1HkeevHgUPHe3ghLo8u1Qt9cx00MEH5i3bLOY5Nka3w4mbA6g==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.2",
-        "@lexical/history": "^0.49.0",
-        "@lexical/plain-text": "^0.49.0",
-        "@lexical/text": "^0.49.0",
-        "@lexical/utils": "^0.49.0",
-        "clsx": "^2.0.0",
-        "lexical": "^0.49.0"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
       }
     },
+    "node_modules/@deepseek-ai/dsh-client-ui-cordis": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-cordis/-/dsh-client-ui-cordis-0.1.5-rc.2.tgz",
+      "integrity": "sha512-wLolxQURdqIXNLcoGmiXb6tE7dPD5v5eBBu7WtUn/w7FNlp4QambxpCfX/ytGy8LtKO42LwhYk9uPPr51COorQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-deliverables": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-deliverables/-/dsh-client-ui-deliverables-0.1.5-rc.2.tgz",
+      "integrity": "sha512-RO2XqjCOZfCSkMzlZf1rgg1ZYhLO6Uy2FUsTwkPContjKCGnGWUMtcaRS8LTs1lYgH8+hP50LIf67o/6z8FJxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-browse/-/dsh-client-ui-directory-picker-browse-0.1.5-rc.2.tgz",
+      "integrity": "sha512-DrrcPERnA50Il/1Roc6T3goodqANi0u+nVtQShw2P3FHBwVqdlfUURMQgZgKdHO4JFv2dGnikwf+XhiE41icWw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-directory-picker-native/-/dsh-client-ui-directory-picker-native-0.1.5-rc.2.tgz",
+      "integrity": "sha512-bH3VBqhlXcmkEcnPrnRLecDW9uOdvsaTzfZ8zTUh5ZtexwNhBs6Wv3lN6gZNw457jbP4BnQoEar5fq+rIC5RTw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-goal": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-goal/-/dsh-client-ui-goal-0.1.5-rc.2.tgz",
+      "integrity": "sha512-38+k8tQq61nQjHYLwYfrwOoju+Jlg2hB0xWJrMvPfcZlB5Shjtthm50lW362tK6iJ9GMSfOGIPGuC+nooBD/Yw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-input-trigger": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-input-trigger/-/dsh-client-ui-input-trigger-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Am7qlXQX+Kf3IddzoJDy2/kgtHm3R5hcUFjDQ8tespSWXswPEX+9wsPFugUvjHJkqdpfeE9OTI3jnd8K6sT/BA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-jobs": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-jobs/-/dsh-client-ui-jobs-0.1.5-rc.2.tgz",
+      "integrity": "sha512-/ygltqocItoM+Jh+tnyYJwIpAPTSu6bAWfEkyBunHpHllCjONuFmnpPcLPZTOxKwkjTdQT6XTRdMhmxU7Sageg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-layout": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-layout/-/dsh-client-ui-layout-0.1.5-rc.2.tgz",
+      "integrity": "sha512-N5+kH1W6UjzOuagJEKDenm/Gbs8Y2sz6btdmVKW5dypEEUgVWsQGV0auTC37gsWKWDaWGpfYOpeAa3Ybk6DYbQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-message-feedback": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-message-feedback/-/dsh-client-ui-message-feedback-0.1.5-rc.2.tgz",
+      "integrity": "sha512-LSp6c87DLMiO4B0JCpp00QEHI6VEKSLWydAx7DBjWTma397HLGLwKoaOT7kHZ8ZSkei970LmdBCUxcwo2Mc4tQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-model-selection": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-model-selection/-/dsh-client-ui-model-selection-0.1.5-rc.2.tgz",
+      "integrity": "sha512-AlYjgwb40OOe5InaAFsQEu/KZr5+vYTItXMkFhkP5myzo5fOea0H0xdF29UV12BZ0SaRItacs8GE1kbDB9n5Ew==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-open-in-app": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-open-in-app/-/dsh-client-ui-open-in-app-0.1.5-rc.2.tgz",
+      "integrity": "sha512-UqLrgiNa48kTGJuMHo/f1er8ti3vcktkseUgFVW2WfWiV3ES1CQTyKF3+4gH3ub7RYFN8VteTQ5QKuOZe5WgPg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-permission-presets": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-permission-presets/-/dsh-client-ui-permission-presets-0.1.5-rc.2.tgz",
+      "integrity": "sha512-2iDWBqr8bfhvzuxNW03JptdPtqQs6kHjh4GdBfgudUhFszaJZOBETx83+PfazYqV4daT4N0cE696l8tqqsS5Ow==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-plan": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-plan/-/dsh-client-ui-plan-0.1.5-rc.2.tgz",
+      "integrity": "sha512-3lbKHZA+9gPSXlMpEFA9xVbn7FOTCgP78Tf3buAjTmOnwSF3PRwBQoMeaANro2SoTn4ZuJZjJkpxqe3YDEOc/w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-reference": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-reference/-/dsh-client-ui-reference-0.1.5-rc.2.tgz",
+      "integrity": "sha512-9zNSMWIhG0txbpwbUdHfkPTHYR44rBVl2aKPIcqr8JSUhI+8y8+QZwoykYTnbZXCKo2Ircdm5IXYbMXTbrGCGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-renderer": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-renderer/-/dsh-client-ui-renderer-0.1.5-rc.2.tgz",
+      "integrity": "sha512-otUJ72f1UfL8b/UL+tMdSE+FHqJWErPmHs2AWbad9nHXghNoZjL2bxumOhI3b+Hb1eezhhM+KanlWzIulTIkvw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-schedule": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-schedule/-/dsh-client-ui-schedule-0.1.5-rc.2.tgz",
+      "integrity": "sha512-DjBRHytIkcntXs93cpDSiDCiA6eEegc26ht+ZuE9sdCHNh3eu2GxLihMoKBiVFbepwIsdfuWO2mf40iFH/w82A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-session": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-session/-/dsh-client-ui-session-0.1.5-rc.2.tgz",
+      "integrity": "sha512-EGCG4Ik95obEM1MA3ZVSsPuK7nknQyhfV/qgNg035jn6gtZJxAguuck9qBNuSOC0upx1xTbh+gSJ6bAmS4ugcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings/-/dsh-client-ui-settings-0.1.5-rc.2.tgz",
+      "integrity": "sha512-NsnZLRI2ZDzJJylx9KATuDwrTdJ0FSP93dU5SL5k2G2W4FLUspNvlAmk7bha5Miopfzmfd+h5/NvMdWe8PVVjQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-general": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-general/-/dsh-client-ui-settings-general-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Y/UNa3iwrqLesUVSPLts1xZotenWyybnpU0/oABUt6rkvhDuxVz2w8HltnrVD3ytKzPBSrmlK2vP2YyUaK4z2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-models": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-models/-/dsh-client-ui-settings-models-0.1.5-rc.2.tgz",
+      "integrity": "sha512-L1vxfbVZEDmGlVuEaJcQb60E36l7BMZoICLJf+D7r8Gwcy8kFckGWKS0fbxsz+3Jvm2L0+lINJESzSMC9pMGNA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugin-inventory/-/dsh-client-ui-settings-plugin-inventory-0.1.5-rc.2.tgz",
+      "integrity": "sha512-lpa6KZA/wqYRNi0zHQVrdUEbt4UGHKfughUSpew4sWvd4HymGGyuKF1ksVrioRUdRGAM+f8/VYpXd0ySk4wQ5A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-settings-plugins": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-settings-plugins/-/dsh-client-ui-settings-plugins-0.1.5-rc.2.tgz",
+      "integrity": "sha512-MRErIAbG1GjrIDN/ULFEMrBA5rHUfg55+uY2P51UVmLdI5UC3B6I5QQYNo9pPcqHSVnT8EZFz7ZWz4Yi5DTAuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar/-/dsh-client-ui-sidebar-0.1.5-rc.2.tgz",
+      "integrity": "sha512-52PGlC4e9zkD6MQOjDo2TakxsWi4f5QigmdNsHluhDMBUfwMYl8ppWGD3uuHyAkK95yh0D1eKI5UPdQ5kikn+A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar-documentpreview": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-documentpreview/-/dsh-client-ui-sidebar-documentpreview-0.1.5-rc.2.tgz",
+      "integrity": "sha512-HeaqHwOyCg6/3ppFP7///G8C4vmVrhRBP8R0w31PLWIv9dcpnULKuFLFO7UemeBsi8K7uQ5zwN7V25DoT05X7w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar-files": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-files/-/dsh-client-ui-sidebar-files-0.1.5-rc.2.tgz",
+      "integrity": "sha512-ZJCpQNruk1Sm29wce30+ATjFkvnuhd55yB3wb+9WpeN+hW6jPmBnAmvUGbS4JsWqpimHLL4y8xYUd5AzAe7+sQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-sidebar-right": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-sidebar-right/-/dsh-client-ui-sidebar-right-0.1.5-rc.2.tgz",
+      "integrity": "sha512-EqKZ5JuyM+yCd6TVe7NwTmZf9y7dyhcLczpnu5rG87RuwVufEz1ARqO9TBXf32ApXCeYOJQGVeJjR/VsYzVMgA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-skill": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-skill/-/dsh-client-ui-skill-0.1.5-rc.2.tgz",
+      "integrity": "sha512-aVBAA4cp79MRE98yVyFjosz8BAn4W5U2DFGF7BxmDYKNmFEp7Ae0THGNn9VXZg5wfmTH6fTAzQKw1THSv+EVWA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-subagent": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-subagent/-/dsh-client-ui-subagent-0.1.5-rc.2.tgz",
+      "integrity": "sha512-/SWymLiSOzYswhikUo+VAuTc4dYkTecw+8vtex0H5IsCsRHlDaTnHgcxXnlvgeqFFifjanr4JzVhwzg9Ope2dA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-theme": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-theme/-/dsh-client-ui-theme-0.1.5-rc.2.tgz",
+      "integrity": "sha512-qLR/6E/AzHUpTgKn8P0TiHiWg69qXYFfbpfHWM+HpQ66K7lyRQUXC+WKEJf2ZStCF4/enkx/rhMdXzRDlPVO3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-tool": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-tool/-/dsh-client-ui-tool-0.1.5-rc.2.tgz",
+      "integrity": "sha512-ncGDBvf7EpuDkq8KteGqQoUCcYkLWlGWNHPZScF8B92zdftYjlnsiQJZCkFbDiyRju3z7PAV3qdY0WO9hOTs3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-trajectory": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-trajectory/-/dsh-client-ui-trajectory-0.1.5-rc.2.tgz",
+      "integrity": "sha512-QiCP1h1bgHG05vlJL5hde3hZPfTuSdwRrszgfY7Jy2NfkuIX6wqv8TI5zsZsEkS2/ha3Ebp3nhjDfkXsGZpgbQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-user-questions": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-user-questions/-/dsh-client-ui-user-questions-0.1.5-rc.2.tgz",
+      "integrity": "sha512-vJzqgAIAlGX7oth3a4qVq3pyyBRc4paL7ENOnt1kfmY+XoPTGF+/CUXwe/Lep5Xjo+95K2HPq7tMxeryKJj72g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workflow-run": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workflow-run/-/dsh-client-ui-workflow-run-0.1.5-rc.2.tgz",
+      "integrity": "sha512-dFpAilctrJhwwZY/XXVvTy73v9UhAPqbuEMIK3sMBFtoAg+S/gCQsiVX/WV5/WCADWdjHLtBoEVAsZgrnImbHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-client-ui-workspace": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-ui-workspace/-/dsh-client-ui-workspace-0.1.5-rc.2.tgz",
+      "integrity": "sha512-BRe/RDIJJblCECYLwVroy8h4+cXrf3eXSfLjJ6BdpnW2fI3CBJuEKlFaBPGtKAFTTain0rQ+dP6SscZNrXm5Gw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cmdline": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cmdline/-/dsh-cmdline-0.1.5-rc.2.tgz",
+      "integrity": "sha512-sfjqgFojZRprFx0oKCI2J1GX2BZ+mgWq8bYX9CktFt3OGlLgmFE5JJ/nNSLKtCjRoXok7KXhsYFcH0dZGlkUsQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
+      }
+    },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.2-rc.1.tgz",
-      "integrity": "sha512-dv5UszPJb/AFcarZc2c6h5z/X80bsrSd3bfIOugwNVclSI6P+L3ixseoZKgyks7T0Ap0h6ngXGk2WeoUkmYxnQ==",
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.5-rc.2.tgz",
+      "integrity": "sha512-qex3bvQNBkv1eapi8iTyNq+c52q1kxfdv5+8Nkswv4/kwrkvcDa4n4iiCbEgKS+K5U4DiVIprnyIv8Nx7il7Nw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-code-runtime-worker-thread": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime-worker-thread/-/dsh-code-runtime-worker-thread-0.1.5-rc.2.tgz",
+      "integrity": "sha512-eXrkDTWlc/ZH2A6S1bP1An2AgfQjmaMRmCKJU1mUzvENO7sLTo++GFR6L1CRLRkFxB8VGZo1TYFKtBxNKsdbaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-command-compact": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-compact/-/dsh-command-compact-0.1.5-rc.2.tgz",
+      "integrity": "sha512-TBvpsgCLLXvnyuVYV+eiAyL/xkl0dG2j1GUVC2mxwPov1jLiKgLqneZClJpo9gT192HAkGIs8a7wXCoID2ryag==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-command-feedback": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-feedback/-/dsh-command-feedback-0.1.5-rc.2.tgz",
+      "integrity": "sha512-7bXJ5IiSzaCbNUffWboAvMXze4N/GTID7O8loSsKBbeAo4CIS6lOWxyx8ZSrcQv/Gnd4onxizN6WqIMxW6i5Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-command-goal": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-command-goal/-/dsh-command-goal-0.1.5-rc.2.tgz",
+      "integrity": "sha512-wNxZKEBC6bAHd92fzKJjyPnYsZJ7yq13p+5wLufNPZrty7y1nlJ8lm7SwxuPZyXYJ9+/5njYlMnZNNZFmitJCA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-commands": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.5-rc.2.tgz",
+      "integrity": "sha512-ODc9h2Jig+Lo4XLdxqHpHjSXsBFeUCth6Y/rToor4KVRWQMedUARlq5otPyB1lYHyQh2DonNs2uf7g3mvag57A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-crypto": "^0.1.5-rc.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-compaction": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.5-rc.2.tgz",
+      "integrity": "sha512-aYCBBcmodNycKjaX9hWChxi2+YYMKlfiIfrNaL9QwtXs0BLvsv2/ttZqGxCebLGv6XdHWozNadC+opFpUCeZAA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-compaction-basic": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-basic/-/dsh-compaction-basic-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Tz6aEvPunsp+SXQruXTldxnZIMLPwXL3ZkWWiWnCM+83r1PglVBWABrxjaRkMaIEype/R16OjxodzR4k7GNA1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-compaction-tool-result-pruner": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction-tool-result-pruner/-/dsh-compaction-tool-result-pruner-0.1.5-rc.2.tgz",
+      "integrity": "sha512-JsCZrbStt2EehHSLXU4CFKJW8idc0xefqCOh101bW4El26JShEKoJKTUwIMvRPq7AQh9RBWk25Pf9N1yAjKuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-token-meter": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cordis-client-runner": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-client-runner/-/dsh-cordis-client-runner-0.1.5-rc.2.tgz",
+      "integrity": "sha512-RFzivtNX2Zx5wTR+9XnawzoxDViti44QoGEamhLP5+Jc0X8BMPVemYB9755UL3YRqgASNQ2x0IrJgBoc813jAg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.5-rc.2.tgz",
+      "integrity": "sha512-VUvOt3L7D7EJEMO2Cetlv0UMY1haIzI401W5kO1AKgOHktGr5SC+wFk83SHX7v2/CS0g1N3PbQ3D+RslutqPjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-credentials": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.5-rc.2.tgz",
+      "integrity": "sha512-TfX5MYLlyw0BFERj3dGxVfP9QGcKZUE5eXDSaY7ZfJbfQgK51VfxV5tP899OxIDRD3Bw94K5Rzx+dbUTSWJBtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-credentials-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials-local/-/dsh-credentials-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Xaz/giXBtfwWP/jd/o1QwKDCurGjZVfVXEfFZvXfzGJ1pdQiMFdt/1nfCnIkktHO2fHhtxEE4MBg10PBLtmp7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^4.0.3",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-deepseek-llm-api-extensions": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deepseek-llm-api-extensions/-/dsh-deepseek-llm-api-extensions-0.1.5-rc.2.tgz",
+      "integrity": "sha512-zue4FWkj7Srg8mAwA6XNqT560NkraILiYtAwIcpT4mmt1Nlim+m55x7ACNkwA5Es0uCkEFAU1H6wHSnR7l2EfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-deque": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-deque/-/dsh-deque-0.1.5-rc.2.tgz",
+      "integrity": "sha512-j1dINwK5XU8f+GPdzx22o2GvsAEhCvnLxqZfEqaLGYImbvdLkToVuU7M2nVcNSU+B7v+kl39lWf3E5u6tzG8RQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-file-reference": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.5-rc.2.tgz",
+      "integrity": "sha512-vJIHFFn3YmipM5X9SgPglnUO4jpvlCh3Yr3JQYITRtpBkL4hBbleayICP8cCmrfN0prstJ8dtIuXkUANu7decw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-file-reference-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference-local/-/dsh-file-reference-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-WYTbwUD5TFWExRttqeNRPBk0EF6xfngevyQyNMRu3fgWYVrHHW9vtR7iGAs/mxAqCgTwZw4vAhCnw1HxaYYLqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-file-reference": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-fs": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs/-/dsh-fs-0.1.5-rc.2.tgz",
+      "integrity": "sha512-6DHTquXPbpYdykGayqYaXSI9t668tDCoswH/bDezV+nwj4LxjrfY/smEtgp7nC4ubyoKf1hmjpNfUonGC9e7aA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-fs-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-local/-/dsh-fs-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-akUTz9D/N0ruSOzytZ8SZ330SdzG75fd7DzHsJ7KJzSif/QM0Y+RpOmGMnjlJzit4HDV2A4Etn80wSzstyp82A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-fs-observation-policy": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-observation-policy/-/dsh-fs-observation-policy-0.1.5-rc.2.tgz",
+      "integrity": "sha512-AntY5dfkTL8WugNGHkJxCEffaTFHqdXaYm7ZrerexnLiZQscDRRjf9zI00JwOmlFM/IrioCuLf5cERfhZN5GYw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-fs-sandbox": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-fs-sandbox/-/dsh-fs-sandbox-0.1.5-rc.2.tgz",
+      "integrity": "sha512-eUxNsnM+TsjGw5OleOIcAhMnFhmQ4OAZoBYeiRMSeOMuCKWEjhxUGN8S8Hg1HxPaZVeIrUV7qFsNQzhehKj7wg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-goal": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.5-rc.2.tgz",
+      "integrity": "sha512-atFJaoijwAz5yZ119f82I7jMx3tGCwXOz6qoY0Likb2c5DpumWZTJgs5L19OhKbhvEW+r2MAC4MYKaUxtrbb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-goal-round-driver": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal-round-driver/-/dsh-goal-round-driver-0.1.5-rc.2.tgz",
+      "integrity": "sha512-9uEhBTqIVxJklNkxCvDDD9upyEa6mIYlB5kfan37zixGDfKSgj83VSwXjJhVqN0b/2CLQDuPxtXgFuSdItoR0g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-headless": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-headless/-/dsh-headless-0.1.5-rc.2.tgz",
+      "integrity": "sha512-EJ0QCWo+0WCTq2SFFRZpbMcGwkSh/uBRNJmE6nx9Eh1Qlt4y3I4G3k+p2mn276ujPbGfEadaI5KLciLOHsZQXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-headless/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-home-paths": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Ek+DH9+MTiulfWDMKo5r335k4I9XIItk+jq8YaPihpK3klSeiKLW/SpKJhFodRnW1CwEyjIlt2XriycRvceIiw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-hook-protocol": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hook-protocol/-/dsh-hook-protocol-0.1.5-rc.2.tgz",
+      "integrity": "sha512-qJ0AlRhLsj31tro0vzubhXarigq8EDi3PwyOxxhoSxZUbGqOBWx+QLNEOC5E5tuob6DYA64Qbmgh7Cbz8vYgiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-hooks-claude-code": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-claude-code/-/dsh-hooks-claude-code-0.1.5-rc.2.tgz",
+      "integrity": "sha512-wdsl+A8tvAk66N5ozqyxmJ5t30AQQ5byBaKYL60Vx1jFoWXaD83piPcD1BAPZ+hVoWI1a9PCUDowFzAzq/PnwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-hook-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-hooks-codex": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-hooks-codex/-/dsh-hooks-codex-0.1.5-rc.2.tgz",
+      "integrity": "sha512-WVmZIWJJ04A7rpe80wcd4+O4MfJbBJdtiPwM99B2DASpm/Igyz3t0mNzNfbWe3zmznRKTHFz1imqhaPdceY1Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-hook-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.5-rc.2.tgz",
+      "integrity": "sha512-a0fVQTX0tM7Zl+1WWkCO3Pd+64CW1CwfOJrNxpTuz7EOp6wOtsYDRHlDyJUSKAOMJArS4xN2qkkt8n3eIkNkbQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-auto": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-auto/-/dsh-host-directory-picker-auto-0.1.5-rc.2.tgz",
+      "integrity": "sha512-R6nl8L/xAd1kmlCZc8xOl4jxp69HMmZ75vWdRswM3MXrM3GIgNiF7AKwK0JlNIKPc6M4vsC3sGMR4yR0XtdhrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-browse": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-browse/-/dsh-host-directory-picker-browse-0.1.5-rc.2.tgz",
+      "integrity": "sha512-8xnMfNt5XcO81qshrC/zzD2NYfLKYEQjVzcu7r+u/ymro7jLypRAp7DQFGuRZiQV4jIF9bdTTT2gcCYaXkWi5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-directory-picker-native": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker-native/-/dsh-host-directory-picker-native-0.1.5-rc.2.tgz",
+      "integrity": "sha512-bBsGBR+tE/w9Dw9rM2Lh/4umjYtGnEmQ9YEss7vrKzo/KFuMfgNPkXHKb6A+AoCfSVd7L7PqkocoA5qVRQND2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-host-directory-picker": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-native-command": "^0.1.5-rc.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-frontend-static": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-frontend-static/-/dsh-host-frontend-static-0.1.5-rc.2.tgz",
+      "integrity": "sha512-cTc0vTyejoYBE0XWOXw/nEDTcveAF9ucYEcaUVintvoo4b4WGG8fuTZSJX9EVkvXggAvxvFjSiYAQ8o2zP7qrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-open-in-app": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-open-in-app/-/dsh-host-open-in-app-0.1.5-rc.2.tgz",
+      "integrity": "sha512-8CBzeDQYMmz4IG7xp7a8mp0xeQ9v6FS9qcN2pOdfRBTXmMk8zHroBpiuW+26yEQmP4HsAi1BECgcWQ03eNoOCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-native-command": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.5-rc.2.tgz",
+      "integrity": "sha512-U7RTRLRs+O18ru6KzUy7LvMk/IgXnkWSalogg0abfA+QU020XZi+UpwZqM567RzC7MtpxijQk8bulGunu0lifw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-host-webserver": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.5-rc.2.tgz",
+      "integrity": "sha512-lFgGm9wDrHiTBANzsdoWzdfPSjWYuDFwCoNQ4Uko57Fo5XASL2unfRHGm1xZ828rwEYuGwRvJHMOuoP/17VmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "compression": "^1.8.1",
+        "negotiator": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-http-proxy": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-http-proxy/-/dsh-http-proxy-0.1.5-rc.2.tgz",
+      "integrity": "sha512-dRK8SMoxyY1F1ulzfnslI++9RDvXLGkPxahUwrnSQl8gTL9R69ZEh6P9dtcIVWMbstaYcq4CqWvo2/qUHSYRhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici": "^8.10.0"
+      },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-rc.1.tgz",
-      "integrity": "sha512-zSjuFJYcEB94kPwn7SicqAV1dfVWZkjt1I8luDboxtjfp5CN6ziwJhLv3KaB+Dh9tgkyGY4mvo886W/HhE9L9g==",
-      "dev": true,
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.5-rc.2.tgz",
+      "integrity": "sha512-oUxttB2yjAgkk47AiXOCxk9GwnfGvIEGsQfnMD7fukwIdD3KLJObU7+nz63tbFN80rjwMI8rg+p9QBQ10KU5+g==",
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
       },
@@ -191,18 +2529,60 @@
         "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.2-rc.1.tgz",
-      "integrity": "sha512-7VYsha5AXsVLnsAwYJffWXz9bwUbElw8i5N8tlTSdai9Bupk3sMbsotzPf8ZbsuGAxQYErahMwQwgGEu4qZO6g==",
+    "node_modules/@deepseek-ai/dsh-jobs": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.5-rc.2.tgz",
+      "integrity": "sha512-C3rBEuWhtDBlxMeKykFvSfBwjSPxkLsvKCFq8BrFdjDmZC1lI9GooMjPZkPxXVbogVrcOBaYVtJdOYJ4+rIpQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-jobs-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs-local/-/dsh-jobs-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-PCDLSktONJ+If3QCcPlRskVLXIa8hG/l0pBIgKNllz4mb7CmYlJ5w1H9pWyrFZllMO0Wm94ZS9aP3SnUcJ8R1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-util-crypto": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-launch-environment": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-launch-environment/-/dsh-launch-environment-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Cr35kPA3W7skJsPLJhUExLDAjVKCmvJgkog0m8EZ+XdK8RlBDsWiH2peRWFtFOjt8QOOeEkupPs1VDpWORIRyw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Z7BVsBkK24SE4EItQeow8PHms/9GP0DSTi337vTAa/RY7tNg2Snz3INcXUj6CPZfvntQr1in9op9wLI+rfNsqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-crypto": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
         "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
@@ -210,70 +2590,966 @@
         "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-rc.1.tgz",
-      "integrity": "sha512-GHwbzWrGbmE0ZGzAZsXBudpyCM9ENCpXxlKODIaPFbIWhRePh6nH2jW47TAOqCIsPPedWC2p3w8Tx5WAa3I/2A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-rc.1.tgz",
-      "integrity": "sha512-jRGNPTbQcvIx1F2MVmmkoiHLgpC3Btqo1wkl/3JDLlOWRVWKOuaC+5fQiMrFPOYfno6YiX/c2UvmA0td8qB92w==",
+    "node_modules/@deepseek-ai/dsh-llm-deepseek": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-deepseek/-/dsh-llm-deepseek-0.1.5-rc.2.tgz",
+      "integrity": "sha512-qNRbLsE2ro+AfD7NgJwTukQLG82gIkbAISjDHgv0au7TocfPkNkUWSu20mTaBcuLGXzfSgBVn4oYx5N3ws6KVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "eventsource-parser": "^3.1.0"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-rc.1.tgz",
-      "integrity": "sha512-qVWlIzPm4u9vzQ5G/QtE6jeSJ3b3b42hWVJj664BurEZlHbAfdqkhYc1QsoBU+5k5kUEJFHh07z8HxuXA9kTnQ==",
+    "node_modules/@deepseek-ai/dsh-llm-pi-ai": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-pi-ai/-/dsh-llm-pi-ai-0.1.5-rc.2.tgz",
+      "integrity": "sha512-56/TRc857HqapiAia0OyWsKtWPaPOfivx1OMzWYsexhTsIvxIOetrj5IMF+tW6geeSm38vfOffn18gOb97NgEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@earendil-works/pi-ai": "^0.85.1"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-authorization": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-llm-retry": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm-retry/-/dsh-llm-retry-0.1.5-rc.2.tgz",
+      "integrity": "sha512-6jyxD9tdzePZMdA4BdvrbdnqSkNYv2M1Nac84urkOcc3D8Jc+QYMnXrpeDB4fZRWg/l7FoKXtfUdn4Mj3kY5ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-mcp-client": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-mcp-client/-/dsh-mcp-client-0.1.5-rc.2.tgz",
+      "integrity": "sha512-L1uhXptzs63bne3fpe8By30xUu2KzC9bbo8t1RdasnRNxhevNJA/5/Z9ZenuMRh26XZh9THF+DVuudEH8PFIsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-message-feedback": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.5-rc.2.tgz",
+      "integrity": "sha512-oNLajqBpv5bkebQrzByUpNTlQPcCoLoreMKzYN0s6STwtHpTzOqj9vSzwk964TfFAYutcmfQoCHNY7j9jmw6iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-native-command": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.5-rc.2.tgz",
+      "integrity": "sha512-FFkiS4Izm5VC1l0bHuw3yExNDmqW0/ypSLt+RtH24GG/W5ofpFvwjGclYDUzSDa0MP5uPzhTMN6qgM76BAA40g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-output-retention": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.5-rc.2.tgz",
+      "integrity": "sha512-3eOx7EmMkttMcJfF/BT6e8A8b0SzWuLCxU+AdY9jBcU8ffZFspIPtMgJ86yNCMLdoZctbrmeSVwEdweMJWRhLA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-package-manifest": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-package-manifest/-/dsh-package-manifest-0.1.5-rc.2.tgz",
+      "integrity": "sha512-PTieT+tXdV8TNK718JZCd9dpVZR52UMYu5i1nXPDPBpoq1fTP7lLSlgHvDEs6SpoJtdFPGNTe8+7KjELyUDDvw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-permission-presets": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-permission-presets/-/dsh-permission-presets-0.1.5-rc.2.tgz",
+      "integrity": "sha512-WeQ3a+mcWfGjv6PLJGvMIgIZNBiR9mCA+wsjFZvxjtuPdu8p8uILxnaodlXhWpSDQ+8oimRO3eBxNVuJdtX1eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-persona": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-persona/-/dsh-persona-0.1.5-rc.2.tgz",
+      "integrity": "sha512-VYAoj8tmSmwBr8SzDfjoG+t0v4Y/clu7BIWjZB5rnyNXLl5RNiY8kVTttnYRBQE+2jLLXlcR7PBJlYkfig3Kiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-plan-mode": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plan-mode/-/dsh-plan-mode-0.1.5-rc.2.tgz",
+      "integrity": "sha512-veJCNJ8qL1vTG5F1GBpBa+lmtBVm+P3kgXpHBCJbYGmZKyrmHj3kbkiVgqxDdxTwnOoQiVco1OcBQUIO/ofGxA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-session": "^0.1.2-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-questions": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-commands": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-plugin-package-inventory-deepseek/-/dsh-plugin-package-inventory-deepseek-0.1.5-rc.2.tgz",
+      "integrity": "sha512-X/6mHIXFoFj6KSj0NBA2RC1xQaHtKnj1QS703AypNaq9+rxn3su3oFnZeWulLx0Tex4URfSmIo8SD1pkJkgUeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-pwsh-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-local/-/dsh-pwsh-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-TwH/xwDRtgk3LyQraG4VoaIaItFSuorTTqyJ3nzuyLOsXq0I8nNYQr/wuaoRjkiDyzFTDeEVMCKq6zEEoLLz1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-pwsh-sandbox": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-pwsh-sandbox/-/dsh-pwsh-sandbox-0.1.5-rc.2.tgz",
+      "integrity": "sha512-AYTAiy8wQwVoHO47e+hnG73GvHdmg+bKy3bFnrPDANCqnRZh9TJIbkxHxtJnfpBnNCcs2fhhCo6yHtGFYl7KHg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-repeat-tool-reminder": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-repeat-tool-reminder/-/dsh-repeat-tool-reminder-0.1.5-rc.2.tgz",
+      "integrity": "sha512-ZDK8AJOP/hdpCKLfbKbfwgj/flICKEPdJbtdoYsTR5A+BGfq8RIy0BWux0IczDenzNSNa8FXq3gbnwQGTPAJ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox/-/dsh-sandbox-0.1.5-rc.2.tgz",
+      "integrity": "sha512-OTOR6Jj9cey5YkhALG0TBwZ/Z3t986aczH6fLbzoIIegix+gwNaEBOqCWs+exVJ0Z2QuN/ItXzn+xHxW8Y0dcA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-local/-/dsh-sandbox-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-qlbg0X7sR9BE90sfHMuOl0t29XG859jJK8xwf5x8yI9Du0zcmviTlQtvlsT7MgDC9OOw8TEDfRTgbm3VDSXCdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-sandbox-windows-acl": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/node-addon-system": "^0.1.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox-policy": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-policy/-/dsh-sandbox-policy-0.1.5-rc.2.tgz",
+      "integrity": "sha512-QyQSCyLFxljkvmsVWJG0xUrYTiXr1DVOxHWURf7EHnbmvYZgg2B+nFcI58+IeUB2qbB35B1ClW5NQsKjOgDm2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sandbox-windows-acl": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sandbox-windows-acl/-/dsh-sandbox-windows-acl-0.1.5-rc.2.tgz",
+      "integrity": "sha512-GPig5OcIBSYtE5YwVzXqV+ICG68FMI1Fo+ZgyH4Jc73Qlze6A4uZqtCyH/xsmiZfzOZiOLyFB9+gc8lu4tZv3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-win32-process": "^0.1.5-rc.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-schedule": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-schedule/-/dsh-schedule-0.1.5-rc.2.tgz",
+      "integrity": "sha512-SjVt6miSlSX1WQdAyvLf0KyQULIds+bLihr3nIvUAhrVSmoRDzbu2jNrNA5jGCo923+dgjGfLn6iUT6aNDJO3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-scope": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.5-rc.2.tgz",
+      "integrity": "sha512-JwItISje52iVIjlGMNayRVMZrvZU/0i3Gr0s+coND5nBp5lS+pOj9Zf1RQzA5cWjHYCWKmDuQc+m6zGlwmtAeQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-app/-/dsh-sdk-app-0.1.5-rc.2.tgz",
+      "integrity": "sha512-WamfPr7CctpoICsT32UpnLlAZavaEno2zwa3icqqpGdSHY0H+BL8yx/4mmRROIX1/ovMyxTcC5urjptDKy34KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sdk-jsonrpc-server": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-app/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-jsonrpc-server/-/dsh-sdk-jsonrpc-server-0.1.5-rc.2.tgz",
+      "integrity": "sha512-TRVkUngQPKlpHvqS5AZi63zwa+5eG0zp1NwZXzJjdiYhjV2LPICiWVM6EuSbmIRB6tUZMB1MXf4ZSj2OFQWn/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sdk-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-minimal": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-minimal/-/dsh-sdk-minimal-0.1.5-rc.2.tgz",
+      "integrity": "sha512-mWdnFnz+MGU1+xgg4GExF+OkkYxEdaNQdAPFq30m0oP67cWQV0Om+pNBHDeGeguf8MVGLNLJB+iRP3/63LQV/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/cordis-plugin-timer": "^1.1.4",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-loop": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm-deepseek": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-plugin-package-inventory-deepseek": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sdk-app": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sdk-jsonrpc-server": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-log-deepseek": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-terminal-bash": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-bash-persistent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-pwsh-persistent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-sdk-protocol": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-sdk-protocol/-/dsh-sdk-protocol-0.1.5-rc.2.tgz",
+      "integrity": "sha512-ewWYU+2tkcm5rTQtM5F6pYP5S6ox/7j/Gc/xCpXBtVOfUNchI8IUYbVNuea/lGX6XYGCBxpdG1jxV51W1YyWkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.5-rc.2.tgz",
+      "integrity": "sha512-y+klWiGAWR4m4cc4ylurA0cW63673B4N8cr2ANMimweDZAfxL4XVBC7WiD/5DT2DtIhYmVZhz/niyS/WbniUTA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-checkpoint-policy": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-checkpoint-policy/-/dsh-session-checkpoint-policy-0.1.5-rc.2.tgz",
+      "integrity": "sha512-RDaGTq4c49nFfVNq0AiL71z07OhtxoxfXESWppyegxotcdZTpdJTk4wIUto56SuaXi+kNCAP2PEjHC+VM0Z30A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format/-/dsh-session-format-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Bih+d4wQ8ea+sZ1+Hws+ZBG3XpExrSQAtNMJRueFVzfTALhbnzpS5uLYw9qDapdfYYyHURlotQPRImBEpIVGFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format-catalog": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-catalog/-/dsh-session-format-catalog-0.1.5-rc.2.tgz",
+      "integrity": "sha512-UKKVXS551VuTA5hH0cz9s9GjBb8HKdQcM+8Xa4uiviavTy4SOkVO3zmo2Wx43jzgdmChtNiUhc+w9RDOZLc7gQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v0-to-v1": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v1-to-v2": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v2-to-v3": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format-v0-to-v1": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v0-to-v1/-/dsh-session-format-v0-to-v1-0.1.5-rc.2.tgz",
+      "integrity": "sha512-0ff7Rl5JsUHGv223XMRFv0adfy7nV2mUQSRf3N1MZviblnp2c65dArq+ieRGISw6JQL4FAz4LSt6A6zV/D6o0A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format-v1-to-v2": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v1-to-v2/-/dsh-session-format-v1-to-v2-0.1.5-rc.2.tgz",
+      "integrity": "sha512-VI15vcRCFfzmPpUg+BXSqgB9Kd99sVVXbfxGXo/gYRgjCY3JqClRh1CYhj1BDUvL91l7LsLv9Oa63kYXXbCaIw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v0-to-v1": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-format-v2-to-v3": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-format-v2-to-v3/-/dsh-session-format-v2-to-v3-0.1.5-rc.2.tgz",
+      "integrity": "sha512-BO9N4O3HhBrUhyO1ucuk1xa5r1+wYCUPnMTryIrasVnOHI3ndb9ITnPhTEc2m6OXJa3c+wuEWrxc7DJHM1Cx6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v0-to-v1": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v1-to-v2": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-log-deepseek": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-deepseek/-/dsh-session-log-deepseek-0.1.5-rc.2.tgz",
+      "integrity": "sha512-d/PJ5/vsJcbv6ZOOD3pBXH58rBWhhSmWHlfLqH7wDq2wA25e1va290OVKv1wwR05/mZBBQZZXxc7qwT4xnsiyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-deepseek-llm-api-extensions": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-log-export": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-log-export/-/dsh-session-log-export-0.1.5-rc.2.tgz",
+      "integrity": "sha512-eoJWiv/oZQA2S61PpDpkU6kovoN5rQ1ZvOmp3HfKLKqfWzi6La1YP5VyiXi/g0qFjZ3ttZC0N+ckmWjNcGUjzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "fflate": "^0.8.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-persistence": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.5-rc.2.tgz",
+      "integrity": "sha512-0nDeM+H+3YR0CH/IVlhjNL9bDx2G4QbliaLekVxY0jdZHM7RqdN/fWPKjeCKbXcRq6qdn9QcmvXU3uWZdErlIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.5-rc.2.tgz",
+      "integrity": "sha512-nkIXdb5oOV6a05Of+3Wywe3gEB77uQOH1U0M+/SRVziSLX4JkE+us7dbWczOOloZjuUsEV7Il8kZ3R9JLsGqjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-catalog": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-format-v2-to-v3": "^0.1.5-rc.2",
+        "@deepseek-ai/node-addon-system": "^0.1.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-projection": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.5-rc.2.tgz",
+      "integrity": "sha512-WMXGBdbxD1FO1Eu7Qs2FKDXq/kl+z+5b7zGLHdra66eEnShSnQmdF9bXSFQu1sJwba2yF7ueMcBJpWy76gtgQQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-projection-cache": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.5-rc.2.tgz",
+      "integrity": "sha512-dS4GGlgZBBHv0U7C4+pQssApxao8Jbt3tMSGQeRU3xpmR5wP8PucR20wTiFThNrsUjdIs2Q/2IKw5bcnkaHwCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-query": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Ntv/yYwhRhhXO3UkRKc1RIIk4RMLVR6jR8mdphRILEZoxPGjZxMJR95RuZg8TuLERbmGH8AkPAEKD6HWHqWh1g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-todo": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-query-sqlite": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query-sqlite/-/dsh-session-query-sqlite-0.1.5-rc.2.tgz",
+      "integrity": "sha512-7xqyRvcaXfPzK6T96QFTdfEVbYIOz69qcghBoDMwSo66MQ+3DSdH3yTPlvrf3a8Nd9Jek375Upz1h12//FB5Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-query": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-reference": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.5-rc.2.tgz",
+      "integrity": "sha512-SpkwyQp0o28bxc01xwid+s+nVCo1Xs8OGsOqyuPRky4WhZtbuI3HN0q/M7+8EcH+kN/SbUzrDD45Q4FAiiHzbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-output-retention": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-query": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-spill": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-spill": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-stats": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-stats/-/dsh-session-stats-0.1.5-rc.2.tgz",
+      "integrity": "sha512-p0C+g31Xcq5w4FWxS+V2hMfLtb97sHpaHNTaAT1UeVTqpSVHt21qC0PnqfFfOe/OsVkMkWDKWDbLb1cA9SnQ5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-telemetry": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry/-/dsh-session-telemetry-0.1.5-rc.2.tgz",
+      "integrity": "sha512-HCTlVFiyWHNqewD1wLow3kf6dbDBU8GqjHlLO6Es9viYW4GCAALO8FXxdqbWMSLOkwMNMM5xqWrXedjfSmRehA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-telemetry-otel": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-telemetry-otel/-/dsh-session-telemetry-otel-0.1.5-rc.2.tgz",
+      "integrity": "sha512-T2gH6xJ9NNTnEjQG3od1vVIieT3htMShlqTTfOzxIR8YoGf/92KpCq6xVtYx3URm6aJysRpIbtRmoYzVq8Ln7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/api-logs": "^0.220.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.220.0",
+        "@opentelemetry/otlp-exporter-base": "^0.220.0",
+        "@opentelemetry/resources": "^2.9.0",
+        "@opentelemetry/sdk-logs": "^0.220.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-anonymous-user-id": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-command-feedback": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-telemetry": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-title": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.5-rc.2.tgz",
+      "integrity": "sha512-lQ1PzIdySxANbhVM9blxCSlqR0iF2GVCiE9R1Qm0VJJue/G9ZUasz+jGQJeAVZi7PHjVWCALljtqpcnaOZq+6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-first-prompt-llm/-/dsh-session-title-first-prompt-llm-0.1.5-rc.2.tgz",
+      "integrity": "sha512-D+eMbKUadK/9QTkk00TItqvE0ealZek8Tc17HJgdGP7Ya0pSYL3hI03q0U6m7SXJQAAFjENMof3xHS+HmyPhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title-llm": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-title-llm": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title-llm/-/dsh-session-title-llm-0.1.5-rc.2.tgz",
+      "integrity": "sha512-IO80OEJ88AUX6S3c5hgjmrrOAgqvTwg9S/4o40H2btAFPCefj+ioHg9qa6KyMZaaZBe8dGjjdngpsaOvC/QPIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-session-turn-outline": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-turn-outline/-/dsh-session-turn-outline-0.1.5-rc.2.tgz",
+      "integrity": "sha512-z3kVLSv/dqwtOM4ii8FfzmmLuEvp9NJORMvm2MQPkYzBxLrQvfxIRPm5Q6uqmTowFrEcYWu1bQCdg6EdnZJDgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.2-rc.1.tgz",
-      "integrity": "sha512-wMmJ2w5S6I7hgmgPppuAVemltEcTmAa8gvii7fk4T2KGVCuBYgig8xPwQ8Lp2ukLZSzzE6ZVCQxhdYZyJX/USA==",
-      "dev": true,
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.5-rc.2.tgz",
+      "integrity": "sha512-LI2Y6GkEs9ALMW+7S9jHPeEZDXHtG5X6cix1HdJ1rRxTEO5427QlYhMiz45rk7hqZ8ca2O4XFMW8IWXFZQLxmw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1"
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
         "@deepseek-ai/schemastery": "^3.18.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-rc.1.tgz",
-      "integrity": "sha512-7W93PZKIk4CHvjZGgLIxrrEKpk+6t8nQXje1vKR5vG73dfXH0t1MJ5WWH/fngadYc7c6KzM84ihQ66tJqJqyNQ==",
+    "node_modules/@deepseek-ai/dsh-settings-file": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings-file/-/dsh-settings-file-0.1.5-rc.2.tgz",
+      "integrity": "sha512-5bdcCyDLMQyo4sm1g8l4mNjIrsyfn1mu3+9tvGYrDWIw0f1n1YEIWuHp2reyoZpRCMAco9S5N4mDoKF2mc9T/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^4.0.3",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-atomic-write": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-shell": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell/-/dsh-shell-0.1.5-rc.2.tgz",
+      "integrity": "sha512-BfmNN6X0NHN2XleW0fCbtFXedXEppeDQ2oa3WsOTuhvnBftl6QWMWWMM59weE4xXker5fzqOnoJdeBR8D9qR9Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-shell-env": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-shell-env/-/dsh-shell-env-0.1.5-rc.2.tgz",
+      "integrity": "sha512-fFSrfhxfvVYfDxsOuV0cjAeC/PWweW+86uOJWT+2paHXOSgM6MSDe3eTd5DHRDYnjb5XutTYu32pR49cVBHMug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -281,100 +3557,1336 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1"
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.2-rc.1.tgz",
-      "integrity": "sha512-llz11yxWeJB8suKCa6hRLjNBWVaPn3Fbd0XoBS0bkZLhPFzO1mDorx/XMca2GhI7XF9A86CURQcDt+aGjjvqJA==",
+    "node_modules/@deepseek-ai/dsh-skill": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Z1mouW3vTzmYk9OAGUp7S9oOB4k9+qr8BpD7KPAR0nAPX1XOxyKA7zQA/6P0tMS69/aS7UsyLZNz9+RG8ZZ8Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-badge": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-badge/-/dsh-skill-badge-0.1.5-rc.2.tgz",
+      "integrity": "sha512-piOjH/WNjv0If4P3IQLuAsOh0WWbmWBv/06IXd1x7emet/d62nnnAp2gl75pqpYDR6qyavvRLNCqhqBJIudKTw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-filesystem": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill-filesystem/-/dsh-skill-filesystem-0.1.5-rc.2.tgz",
+      "integrity": "sha512-lEZ9KojaIc24vKCa5mp8LBHUDoXpNRSR/vlMsWONc9Tc1wwfn9kEotIjj0HD4PjIRcnc+Lma1nk4G/oNED8A9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "chokidar": "^5.0.0",
+        "yaml": "^2.4.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-home-paths": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-skill-filesystem/node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-spill": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill/-/dsh-spill-0.1.5-rc.2.tgz",
+      "integrity": "sha512-djiz5HH1xtuxiBAPT6ODlwEPUQz/SR/Q6SCUiEud7x90nmTsfLLxGUQmNETdiRC3juBLZeoDV1Xgmjf54P4y+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-spill-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-local/-/dsh-spill-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-HrTEyP/KJh9YudGYmXBZvu54x022JWIlVX96d2UkHKICSB1NJy3AUIO0zyYCOk1PX+4iC77oD6zdOAyyxX21QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-spill": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-spill-policy": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-spill-policy/-/dsh-spill-policy-0.1.5-rc.2.tgz",
+      "integrity": "sha512-XDtIEF7eeErjf0HS6ASkquXZIorv96+A3kuSZs9ZoWqI6eHVxUBrTebHhNc59P9Cp6LeumLUhPIb+SEP3ITgYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-output-retention": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-spill": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-storage": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.5-rc.2.tgz",
+      "integrity": "sha512-mYt6+JSRxA5fSUcYnI3JFvYw9/TKUyykz5JWoZZ3MxWudItfhw+CV6T3kn3/bpTbWIQnGesSeY+0pJJVz0xBAA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-rc.1.tgz",
-      "integrity": "sha512-W9kUio00s7WbM8kEwniyd4hfb3CeUxVczsjXbOcKtakfiTywNLeyRWkpx2fvwRAH2rBfg3qCgczVfS0DOw1csg==",
+    "node_modules/@deepseek-ai/dsh-storage-domain": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.5-rc.2.tgz",
+      "integrity": "sha512-NZ9U14kqcCnF4F+ynrTlBLb+S9FEOwSLkfdjDgdfrFdHh4c2WsRKWxyeYbL8AME1rB+XxLp4YQBx8LQ0Kiy62A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-util-values": "^0.1.2-rc.1",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-storage": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-storage-json": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-json/-/dsh-storage-json-0.1.5-rc.2.tgz",
+      "integrity": "sha512-vIdKeI6BUQpqneD/+oTZ2YNotNSGXZX0VbFbhdvgMSgamOrExIjl4cRsEJttcNr8zSvB8PjmuX2wPFvkMoeAlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-user-approval": "^0.1.2-rc.1"
+        "@deepseek-ai/dsh-storage": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subagent": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.5-rc.2.tgz",
+      "integrity": "sha512-f2wbfB1M2P8RpcApp5eDpDQR4V5ElvEkeK6su7tor1U06uJadJ+JuIVXP3MrCnT7yjg/IM2tTacYFMOg62BOfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-chunked-list": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection-cache": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-query": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-time": "^0.1.5-rc.2"
+      },
+      "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent-presets": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-jobs": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-sandbox-policy": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-persistence": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-projection-cache": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-session-query": {
+          "optional": true
+        },
+        "@deepseek-ai/dsh-user-approval": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subagent-fork-in-process": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-fork-in-process/-/dsh-subagent-fork-in-process-0.1.5-rc.2.tgz",
+      "integrity": "sha512-9VHI9pA1FX7mEOUx8Iw7Q6Sqk76rJGsOCQ0jwsaE+7YvQxV8YhOFe9gBzkmk+ChRNag5ToBVLFuUFROpboo+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subagent-in-process-driver": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-in-process-driver/-/dsh-subagent-in-process-driver-0.1.5-rc.2.tgz",
+      "integrity": "sha512-IBwRQHVX4hi3YO2vUYmTtDxKM2B0lIwAuiAG3hsvljmaF66z2snyLYezKszLZeTPphr2QHgt2CJNxNP1LlhUJg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subagent-spawn-in-process": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent-spawn-in-process/-/dsh-subagent-spawn-in-process-0.1.5-rc.2.tgz",
+      "integrity": "sha512-/FJxY+dBc8AVWFmSYcQPWapuTd3ATGQpAb9Z2cQEZjFRXy8ySuZnh2MrnAa/r00FX6Lz0G8BfvUurr4K+uKHSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent-in-process-driver": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subprocess": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess/-/dsh-subprocess-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Bbxg5/dlbK09qNu4/BVuicUAYnC+b/YGhtkUBsxa9/+KRfvloeJcJ9Ug6dKAeJeluzEXnFIh08+MNweO7hn7ig==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-http-proxy": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-subprocess-local": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subprocess-local/-/dsh-subprocess-local-0.1.5-rc.2.tgz",
+      "integrity": "sha512-DmG3lcQlAh8bTKfeyYM44cfRyJktbLL8drXrVfOvGrFk0zSs5eTSLcfhIKLT3jFJ5CKFriHYZPLdRT6Alvyy4w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-win32-process": "^0.1.5-rc.2",
+        "koffi": "^3.1.0",
+        "node-pty": "1.2.0-beta.15"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-system-prompt": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.5-rc.2.tgz",
+      "integrity": "sha512-VtmZVKqBMJ7kzskHu0jY+Jth7jSuKMG8QB3MBPzJe9M0LL4YPMWsGKt9gGky9RXolk/ugAy4YZEv1gUqouVofA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-terminal": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal/-/dsh-terminal-0.1.5-rc.2.tgz",
+      "integrity": "sha512-ALDjWfRMWvRmk/HfM7z5sXfQ1DSarJcjkzL8bT1KV01WlJB1KHVbXKlLI29tQH1Zu92uXk9g0JaFQKNycqT9yQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-terminal-bash": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-terminal-bash/-/dsh-terminal-bash-0.1.5-rc.2.tgz",
+      "integrity": "sha512-UJVx058VgMNjwptwlGPBsMCmAs/ljgQwW9RNDZCpxvKxtc6D4RqEm675/f4uMPnGEKhPCJFKCGZy3ltqHvUPdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-pwsh-local": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@xterm/headless": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-time-context": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-time-context/-/dsh-time-context-0.1.5-rc.2.tgz",
+      "integrity": "sha512-XClt8a3ijmELHrMuPG8F+P7uLbi+ZBcjulTdeMq7UB4yRSmTHNcQ1rJLyPjPajSDsR6F81x6z6xT842PC4u1kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-timeout": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.5-rc.2.tgz",
+      "integrity": "sha512-FgfaAw8Zt5X4Y6Ljh833B8Hy7h96FeR+yjNKI3iSyZSqREqOBgvDGXFfQlSu6V3Buvw/cbI/CJUQJvfRBKXOiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tmux-context": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tmux-context/-/dsh-tmux-context-0.1.5-rc.2.tgz",
+      "integrity": "sha512-gocDAjUDx80DkbS92/WZJqx+NJkTfuGnSBglDXdUZRFj5O38Ggl9ywSKxTISk/Yhj3SbjRab9UfNjBZ1M8Nlxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-token-meter": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-token-meter/-/dsh-token-meter-0.1.5-rc.2.tgz",
+      "integrity": "sha512-GS13T/USWa8pFBsahLGQCTQ31ktIa5iBqUYyFFrDPKhvUZFk7dTgltqIo9BxpsU5op0Lwj1LFyCnhNnuYbzvaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-compaction": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm-retry": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-ask-user": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ask-user/-/dsh-tool-ask-user-0.1.5-rc.2.tgz",
+      "integrity": "sha512-M+ha4uty4SM/nEfkOeIMw7vxj3Ez6lZin6oQqgw5hWXNrmf5C9SfF8VH6KZYuPhsmxPiyTUr5SyULxgn2eTUGA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-questions": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-bash": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash/-/dsh-tool-bash-0.1.5-rc.2.tgz",
+      "integrity": "sha512-f4LmiZkZSfJfvBcEzV4q5J83VL79l/+ncLkwnJyHzsjvJbW5qFxzCy4p5FXfY/CflG0taG14/p42UJzb9qEhrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell-env": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-bash-persistent": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-bash-persistent/-/dsh-tool-bash-persistent-0.1.5-rc.2.tgz",
+      "integrity": "sha512-OCfqQijK/eo+ILLatQntWnKJ7hFwUUOLpxdbkgmN8zjvD3o3LPRnnt9IerCid4YjGwc69jSTBX0Zk2jW2n/rhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-call-timeout-policy": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-call-timeout-policy/-/dsh-tool-call-timeout-policy-0.1.5-rc.2.tgz",
+      "integrity": "sha512-B8lBJ6FHT3eqfQupHANU6JGwSvqp4EGYSGgOiNh1EVwXNn5MeX1AztQO+sNqWl69nof9d7/7vxXmTeS7rmIFXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-cordis": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-cordis/-/dsh-tool-cordis-0.1.5-rc.2.tgz",
+      "integrity": "sha512-bm1p2cRmXvO5b4oj2YHvF6OFh8EcHJQREcD52SEkSWtdkeakHbwMEOeCLfSWSNMUiNeOa7tMutUQrepdCS37EA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-fs": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs/-/dsh-tool-fs-0.1.5-rc.2.tgz",
+      "integrity": "sha512-/3AUx+V1UxVfl24fm10hwRbJnHwpBkRDHniOeocGknMvASheRiKnHpnnj9EszFRLYSpe2PRFSMuyuhXgYyd3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "diff": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-fs-search": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-fs-search/-/dsh-tool-fs-search-0.1.5-rc.2.tgz",
+      "integrity": "sha512-B4UrzbrigYiD8IKweuVzOHHLrhKfBPWTxscPDy0WmaYJ+aYQ/qaix9RgxnmJRoF8aVo4lw/Fzlz6hq30ahwUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@vscode/ripgrep": "^1.18.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-output-retention": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-spill": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-goal": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-goal/-/dsh-tool-goal-0.1.5-rc.2.tgz",
+      "integrity": "sha512-nZ0NkUxvtAsrPAd9NMXt+4kS7WPn8xIvXCwVunKfBwbrnGnFCNmIsTQoHF44J6q9VbMeSCN2eyj07w6ej3Hf+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-goal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-jobs": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-jobs/-/dsh-tool-jobs-0.1.5-rc.2.tgz",
+      "integrity": "sha512-v4y56H3FsVBF2jUJLGLHdPeKaKJxLT4Zx/oii45UmJv5t8Bp3uCTVUoq/mfSFVuFY66q6rHJwgIOKWc4ZO3ySw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-output-retention": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-present": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-present/-/dsh-tool-present-0.1.5-rc.2.tgz",
+      "integrity": "sha512-WWxjEgh/nPsATfofNc0Qi+Eshy9LPNAYM+UWWisuKcT6smtv7+pR8Bk79RJu5BiFog8Nq17mwEh5XnFlDIg8FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-pwsh": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh/-/dsh-tool-pwsh-0.1.5-rc.2.tgz",
+      "integrity": "sha512-rnHM3Jqlr7rthwfPYysXPq6zH+K8JTDqbE+xzjkbo1WIBKBZeSGr8kPjqdCZa7eUtWhmV/RFBP1qmBgDjEZaWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-shell-env": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-pwsh-persistent": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-pwsh-persistent/-/dsh-tool-pwsh-persistent-0.1.5-rc.2.tgz",
+      "integrity": "sha512-NToI2tXkbAZS6Cxjnn7VjgCF7o68vMquvmpVh6RjTXAsawNY0TMmAVo67bREDw07+1j/bTq8EPywrJSmBbS2Fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-terminal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-ralph": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-ralph/-/dsh-tool-ralph-0.1.5-rc.2.tgz",
+      "integrity": "sha512-qP7KoVUBPLvvPSiJBXJtQt6c5ChnJRs5ZJnW/VU2DbBjYn4lkN6BiSfpRsSfjRGKO9fmldn2BYR0OnSLXi57xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-workflow": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-skill": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-skill/-/dsh-tool-skill-0.1.5-rc.2.tgz",
+      "integrity": "sha512-J0AshOq06tVWFbESolUP+9TEYXymASMULsWsqTBAgaIjzbZjhJ3x2CPMP54gM8uROh/y0qGBhVUErJeamP9AhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-skill": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-str-replace-editor": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-str-replace-editor/-/dsh-tool-str-replace-editor-0.1.5-rc.2.tgz",
+      "integrity": "sha512-SqxB7jgmAURwttFMQ9CmM4l1n5pdMA1ofPOd0Fp2OqYRdo8C0NCO0YN06PtX3CvmjI6vjDUT3grXqETzhmN3gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-fs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-sandbox-policy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-subagent": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent/-/dsh-tool-subagent-0.1.5-rc.2.tgz",
+      "integrity": "sha512-6H7iL1UMcPrQTZrmp/olatipQzg6z5b3xqqPpW26qhgX9tDttJJGAspObePM8Zj02EO9ibz7QLg/VIehPuu+sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-subagent-control": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-subagent-control/-/dsh-tool-subagent-control-0.1.5-rc.2.tgz",
+      "integrity": "sha512-kuSx9UGDBUSrffTPnNetKj7mUmH1+24BQT+589vaN5epO8GKZ1STzIR3IINn+kMP0t9MAGIhEsa39b30OQu9nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-todo": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-todo/-/dsh-tool-todo-0.1.5-rc.2.tgz",
+      "integrity": "sha512-TmyoAthal1pOCQ/XwlohcxDXdI5pq5GlZiQpLaI7e+rAruqneBPz/0Zjv6/rlOMrseoENMx+H0sazwoL9LufTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-web": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-web/-/dsh-tool-web-0.1.5-rc.2.tgz",
+      "integrity": "sha512-FPHiDBHjyO/2ayVcUL8tmcBqc+Fi8Y0zcQuzsFw6/K8pOJvP/pBSN8mXi4tBVmmqXg25ZXVo1vDDo4T1mBIlFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@joplin/turndown-plugin-gfm": "^1.0.67",
+        "turndown": "^7.2.4"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-web": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tool-workflow": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tool-workflow/-/dsh-tool-workflow-0.1.5-rc.2.tgz",
+      "integrity": "sha512-co/4mEKOC5MYXM/x2sdTiIwPfUtK3Bhst7HMwmgcz3PNZG4DEkaqLlzsZyisLn4iQvKChtvdyS5fWwNeC8ws1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-workflow": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-tools": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.5-rc.2.tgz",
+      "integrity": "sha512-k2yZuJJtszaU9lzr2aBtdeFMINrkdlk4ellbtrMokA2oySVqJmAM8dv+u9RtzduD3aRRqyr2i2hWrTACz0qOrA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-loader": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-loader/-/dsh-typert-loader-0.1.5-rc.2.tgz",
+      "integrity": "sha512-5kNw5jLJ1PBGqL9Ma/ym+Uz8pbFhMe2Ci0QypPtE71ViUC8K0usgypqmn3+2vXtBk5E5mI/n3UGu9gyTPdHIYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-typert-registry": "^0.1.5-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.2-rc.1.tgz",
-      "integrity": "sha512-vBWD0NpriPd96ltbWaAw+iKeWFIEjiAcCWYtmqEcV1Ms+FaV02usjjm7LCmhSQhMZpBSBc7EZUX0spGlpjI1bA==",
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.5-rc.2.tgz",
+      "integrity": "sha512-zP8J20rBXa1AFjKL2i83JBeQcePZx8yal3pNojj4t7CCokMcoFMUbr50woa6fY1tRJ7qHxgypO3rH8Q6YWgmiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-typert-registry": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.5-rc.2.tgz",
+      "integrity": "sha512-GBHGD8T4goY8kKA0U1jD2YRPAgkESdVuSNXn7KpYeb3SLtVntt2ND+FMSwNqcMN/zuBm9Yvo5x/nuK+yxFqvBw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-rc.1.tgz",
-      "integrity": "sha512-oYkLE4a/TwqVNi299pUf/QP1Yku6KScdUCTUyYbjaRBcN+/pXPpHikl2aoE2thH9D0uT/Kj6T2kz+wDDcFd9Xg==",
-      "dev": true,
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.5-rc.2.tgz",
+      "integrity": "sha512-8UpMEnEyMo6mYEVELBo0DC2iG7aJJfFMTNkU+DKD3c5Ut7ySRDzt1iRr1qni/CzqlTIpQBAkGaG77qk4q/v1bg==",
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-session": "^0.1.2-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.2-rc.1"
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-user-questions": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.5-rc.2.tgz",
+      "integrity": "sha512-0cRRE9nc9pMxxyC8G8C3859EtPyZR/27FRgRMRe/wDWL30S6JoWWgaw7IFN9FogvaoEp62XV7wQ6ub/eoTqggg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-scope": "^0.1.5-rc.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-util-crypto": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.2-rc.1.tgz",
-      "integrity": "sha512-gE8FznQ1hkknw9QMrHNSlm3UEyRYuj3MLVvlJ6NyH1kmOsdjnbrVbSs+Pn72k2oIV4Fiyu3Umg0sLznUEcsiXw==",
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.5-rc.2.tgz",
+      "integrity": "sha512-JR0aJEUL35RE8FVT89wMZMbPwMrbkjNcy+gE9pq70d/m2Zxw3a0iNer+BAxPAKYPbmy0xDDXReTwXiecKVy4sQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-time": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-time/-/dsh-util-time-0.1.5-rc.2.tgz",
+      "integrity": "sha512-nWJrNCaEBANFUX+Rp2cE1+hA2CGCmktXOo2Nsh524aV2VaLumFFS501IsmI9ghUmUE77qZxvayGGO7w3LLIECQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-util-values": {
-      "version": "0.1.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.2-rc.1.tgz",
-      "integrity": "sha512-FQdgoK+KYVR0pBQb9fTsajvGb3gzUxEzJQEYnFOt+Qdwc4nkxJOPwJJdIvXuqvZaQ33DaOoqpnpcr2p5HpLu4g==",
-      "dev": true,
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Cr0TkM6dFAD+Iy4sNXH/afJVMHwJXoOztivj+RflkYoACsOq+Ix0vdHn36hwW7mayU8OK3ZKIZUQ6BPo1fHvUg==",
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-util-workspace-path": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-workspace-path/-/dsh-util-workspace-path-0.1.5-rc.2.tgz",
+      "integrity": "sha512-RCBz+6BpdPDNsRk2ukIdIIuLdf6u+cS8sLiViFg/8/x/kxc+LEXRKJMy2xv+YA9hYOGFK109rjUFgx9JVtZf2w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web/-/dsh-web-0.1.5-rc.2.tgz",
+      "integrity": "sha512-3qt/Fh+uCghOy2wZPjwQ6xIMU3t1NW4D5yRvTXOyvadwaDwosqXOzCteYUhnuWzWN66adrFLeRrymhSDS4PMeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-app": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-app/-/dsh-web-app-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Ng7YVDt9txh2BlLmu6B+V677c1bihbh/rq3EOtZK4b0JWtgdNgYb1KPIED8+aK2i+FghrCrIy6X60AyJ45eOvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-api-remotes": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-api-session-controller": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-api-settings-controller": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-api-workspace-controller": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-api-workspace-files": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-app-boot": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-connection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-file-upload": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-hmr": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-locale": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-modules": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-resources": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-agent-preset": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-approval": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-attachment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-brand-official": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-chat": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-commands": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-conversation": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-cordis": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-deliverables": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-directory-picker-browse": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-directory-picker-native": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-goal": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-jobs": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-layout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-message-feedback": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-model-selection": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-open-in-app": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-permission-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-plan": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-reference": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-renderer": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-schedule": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings-general": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings-models": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings-plugin-inventory": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar-documentpreview": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar-files": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-sidebar-right": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-skill": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-theme": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-tool": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-trajectory": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-user-questions": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-workflow-run": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-client-ui-workspace": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-cmdline": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-code-runtime-worker-thread": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-cordis-client-runner": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-file-reference": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-file-reference-local": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-auto": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-browse": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-directory-picker-native": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-frontend-static": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-open-in-app": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-message-feedback": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-log-export": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-reference": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-stats": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-turn-outline": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subprocess": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tool-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-web-frontend": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-workspace": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "commander": "^15.0.0",
+        "open": "^11.0.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3",
+        "@deepseek-ai/dsh-shell-env": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-app/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-fetch-http": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-fetch-http/-/dsh-web-fetch-http-0.1.5-rc.2.tgz",
+      "integrity": "sha512-K3us2mU0L1sgnW4FFtDI6UYcL+JZvIbdRLEAO+8oq9lHAuwKuCcb4RPPuyXMI35ue97PkfBgt6A6Sl0utiIF3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "ipaddr.js": "^2.5.0",
+        "undici": "^8.10.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-http-proxy": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-web": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-fetch-http/node_modules/ipaddr.js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.5.0.tgz",
+      "integrity": "sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-web-frontend": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-frontend/-/dsh-web-frontend-0.1.5-rc.2.tgz",
+      "integrity": "sha512-o0+dEbtEzchPnNFkKQ4o3/OekEi+PG8CTEwp1eWWg15TRiZbG2OeUKMsQjPpAVCMDnpEwMQ9skdKcwKj4TXAzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@deepseek-ai/dsh-web-search-deepseek": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-web-search-deepseek/-/dsh-web-search-deepseek-0.1.5-rc.2.tgz",
+      "integrity": "sha512-0r9KqkjnOd7VLwWEAYHOEGLctRwhGLOJ9xnnGuL3nd3uFcrA5Wb1MYbJhGKxx+9XRpTJZyi7Aiex9QRAr8c0Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-launch-environment": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-settings": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-web": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-webhook": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook/-/dsh-webhook-0.1.5-rc.2.tgz",
+      "integrity": "sha512-Tv4aR5JYxq9ODe9lYoFaQWjFUf644tPaSVSgfBMPrynN9X94rcY7HAkYxt3qLggvK/cGrtNOFwyqyOIDTjqyJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-default-model": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-agent-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-permission-presets": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-title": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-workspace": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-webhook-github": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-webhook-github/-/dsh-webhook-github-0.1.5-rc.2.tgz",
+      "integrity": "sha512-esocwn22CYbOAo7WzwWl/E3jsHKOAXFS5e1dnW9b5VNPujnbHdvhXyyNQzUW0nNnxt1QTsIARyhqpDKWuanCcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "@octokit/webhooks": "^14.2.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-credentials": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-host-webserver": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-webhook": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-win32-process": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-win32-process/-/dsh-win32-process-0.1.5-rc.2.tgz",
+      "integrity": "sha512-KWF9pldnznDE1XiD7vjxg+P2cDQHOCJtz8ZQ/P0bLorDog/peQwqxYNgc/nrHxEZ1vWl/vbdd8Nvoen6FJ/Orw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "koffi": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-workflow": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow/-/dsh-workflow-0.1.5-rc.2.tgz",
+      "integrity": "sha512-eGOBiC4RA89zZTTG6hBpTchau55lZ67P/dyqg4kJq8K1FwummTg3xed4Ecy9KQFaSX8rWQP9RMJnaWg1fBgXTA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-workflow-worker-thread": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workflow-worker-thread/-/dsh-workflow-worker-thread-0.1.5-rc.2.tgz",
+      "integrity": "sha512-y8twj+FNYoxaaLWYkr/tQauCHymlY3AUgS5lHEi4tZW1PgYD2mEz7VPHu1nUWX7W6m78gCQvg/6KcDCLrTgvcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.5-rc.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-llm": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-subagent": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-tools": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-workflow": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh-workspace": {
+      "version": "0.1.5-rc.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.5-rc.2.tgz",
+      "integrity": "sha512-J2RIjHk2RNTtQNZ1Dpy1ItdhOmXDsWXLvMNv/MMdvv3NzCjKMYQ8le18lpzboqAZY3I2cOfX0cxu6wHIC96SIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@deepseek-ai/dsh-brand": "^0.1.5-rc.2",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-session-persistence": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-storage": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-storage-domain": "^0.1.5-rc.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.5-rc.2"
+      }
+    },
+    "node_modules/@deepseek-ai/dsh/node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-system": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system/-/node-addon-system-0.1.2.tgz",
+      "integrity": "sha512-EFn8K+mXIXiw6s3rxX+cgp2hZTEAQdVIsURhrXnBxycSXvtQ1EQpsSVzoNKtKAQI0I0VqkEcVEjHzS/PeaGsvw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@deepseek-ai/node-addon-system-darwin-arm64": "0.1.2",
+        "@deepseek-ai/node-addon-system-darwin-x64": "0.1.2",
+        "@deepseek-ai/node-addon-system-linux-arm64": "0.1.2",
+        "@deepseek-ai/node-addon-system-linux-x64": "0.1.2"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-system-darwin-arm64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-darwin-arm64/-/node-addon-system-darwin-arm64-0.1.2.tgz",
+      "integrity": "sha512-IR0cx8um19mLCZaJ+H5PLblKr6Eg3PWvVo8eTQBr/SwH2nh5tM9CD9/5fHweNS9Pjt15UdFlGqnvLSd/w+O6Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-system-darwin-x64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-darwin-x64/-/node-addon-system-darwin-x64-0.1.2.tgz",
+      "integrity": "sha512-XDbmquNapk9aT28y4EKn9lbONVr9YNs1NM/GKH1Gi5gUhjOT9wgRaTv72FJdNaVIInbPAYbPoyn7/y+MzQMNNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-system-linux-arm64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-linux-arm64/-/node-addon-system-linux-arm64-0.1.2.tgz",
+      "integrity": "sha512-Z/DQtqgEYzjBzb2ocHGjMzx51W7xDILkJKKj89nyErr8gZMNiLs+JNL1uKzJqc3VLZB+vYCPaHGyQ3oX6EzEmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@deepseek-ai/node-addon-system-linux-x64": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/node-addon-system-linux-x64/-/node-addon-system-linux-x64-0.1.2.tgz",
+      "integrity": "sha512-S2aPVHvYCpNCppCFyNlooMYuTB7ucK5lvD9oXQQ42v5Z2s5AoaiCdjz9r2l+ED2rI5oS1x0cUZmKjJH2dxV0pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@deepseek-ai/schemastery": {
       "version": "3.18.2",
       "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
       "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.3",
@@ -384,6 +4896,52 @@
     "node_modules/@diqier/stratagate": {
       "resolved": "packages/core",
       "link": true
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.123.0",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.85.1",
+        "@google/genai": "1.52.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.2",
@@ -827,6 +5385,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
@@ -838,6 +5421,540 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@joplin/turndown-plugin-gfm": {
+      "version": "1.0.68",
+      "resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.68.tgz",
+      "integrity": "sha512-m8DfAQNC/V7g0j5H6Jv60WhekBBjodD+zTPGrU+g2m+ux/z8ZX07KQIl6kaAmbKwfvsQhC04op52g63I78sVgg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -878,230 +5995,318 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@lexical/clipboard": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.49.0.tgz",
-      "integrity": "sha512-AVKj21xH1qU7JAFA/v0hCoafa+Yti1I7cHG+JQIgc/EqCtP8ePeJyIfTPNN/tXskoCdq++HewQoiSXRwwlocVg==",
+    "node_modules/@koromix/koffi-android-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-arm64/-/koffi-android-arm64-3.2.1.tgz",
+      "integrity": "sha512-1pJQ4jnZlUJduK9u9DC5CGy3aOgDUPvIXpNb6syV3+Dh5Q/ugezAIGCqvY+w+1mgXsve0pd0NVvJRjdZNHQ6MA==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.49.0",
-        "@lexical/html": "0.49.0",
-        "@lexical/internal": "0.49.0",
-        "@lexical/list": "0.49.0",
-        "@lexical/selection": "0.49.0",
-        "@lexical/utils": "0.49.0",
-        "@types/trusted-types": "^2.0.7",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/dragon": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.49.0.tgz",
-      "integrity": "sha512-62/4DP5qyX/l4Yf5qRyyQrs9BV725eRU3OmLUW6g7T5xrcHXxAo7tia/NvqjqvXdpvQzyHjWgsy7dMitGITUsw==",
+    "node_modules/@koromix/koffi-android-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-android-x64/-/koffi-android-x64-3.2.1.tgz",
+      "integrity": "sha512-HH40xGh3gVQifjOBnhwT2tECC0lL1lYe+nxHvWNSzxDIyQNcVPXg38ta7vuONRFpD+uIrw7fqGYLzbZIagkVcg==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.49.0",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/extension": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.49.0.tgz",
-      "integrity": "sha512-Wv0VsuqxorbxHCK4ms1PwAu6cXIGNLtflq66auF+zwxOtBprkSFV8VzzzdKLOYD2admP0VK6EqVCeGXFK1GggA==",
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.2.1.tgz",
+      "integrity": "sha512-Vj4h+xcjc5+Cn0DhPHjgRX4omKAv96Kehtcd+1YgYuY2W7FvQn9vS+3SmzVwhC5Qmg9bIwUZObYQ8T/4hBqQqA==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/internal": "0.49.0",
-        "@lexical/utils": "0.49.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/history": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.49.0.tgz",
-      "integrity": "sha512-uQdtEd34gIJklXNSdHS2Wko1zxx1xUMVXbiodcLO6a3GeFTE5bKnx6af1zGX78KpYhUQYnHWorKuUvtdZlJPaA==",
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.2.1.tgz",
+      "integrity": "sha512-gFCWxNBTZIvxo1p+PURWfsy2Ctj5FGnVVs1f03lTLhBvmxEto70pdIiFztdFLDFkAJ1pmtQmruRKapeK+E8YPA==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.49.0",
-        "@lexical/utils": "0.49.0",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/html": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.49.0.tgz",
-      "integrity": "sha512-NQqAydKzRjQl7Jx+bTTyC2iuz5uhuDaQX0SSPrdfgaFDCPjqQEejcBkCt1QXnu1CkbVHutZKVGVzljx40Y6y+Q==",
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.2.1.tgz",
+      "integrity": "sha512-qj+f1s2e6vULaUG1cdlTcCXmunCq2t+rjxku1+esaMIqVnHpOwj0QzPuInG0AFdXjwBNQhyVR/HpDj8daEwwsQ==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.49.0",
-        "@lexical/internal": "0.49.0",
-        "@lexical/selection": "0.49.0",
-        "@lexical/utils": "0.49.0",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/internal": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/internal/-/internal-0.49.0.tgz",
-      "integrity": "sha512-s+XjPC7Qb39A/Xx9ahcz1s69CPix4ultaqyW+MDG0AXYW2quDr7m0USqReKIAiuoLIWtGN5HW8BwV2Y6t4qr6Q==",
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-6olHb1Qfgai0jjs6ddlDDD0ZfsCxy7SPi8rMRpuYQWH0qhgtyQu82hw5b1p7z+TJ0zZP3ZeQQ6l+U/MlM1ICHQ==",
+      "cpu": [
+        "ia32"
+      ],
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/list": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.49.0.tgz",
-      "integrity": "sha512-zs6wYkxakDRcJO0KmwrPPHgeLLIxzjD+P2CRu+scJCHRuA5e2iSw2iFjH5n/LlWBrlnPMSjeQse4QqsRy9nnqA==",
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.2.1.tgz",
+      "integrity": "sha512-Dikhw1ySYNVMkmeFvFVjnU5Wdk6mffNoOjJxm9bTG96vg7OlemylxqdEven47R1YJ3yzNVJn/MlQ207ORWfi2w==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.49.0",
-        "@lexical/html": "0.49.0",
-        "@lexical/internal": "0.49.0",
-        "@lexical/utils": "0.49.0",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/plain-text": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.49.0.tgz",
-      "integrity": "sha512-l7IuUj9n9CtFfz4Fz6zU6mmO+VkcnvyyebABx+lHevvTa7B6YI5PPVgABFfzdyPanyW/FGs7qpKBf59inAqbkg==",
+    "node_modules/@koromix/koffi-linux-arm": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm/-/koffi-linux-arm-3.2.1.tgz",
+      "integrity": "sha512-OfwUwZylidq95wQKp6ClInULrfB2giu7dqM6Rhe0zAe6lES5I2SXNw15T9+GnRHk3/9hKT2XZ37OZLaKSyWNLA==",
+      "cpu": [
+        "arm"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/clipboard": "0.49.0",
-        "@lexical/dragon": "0.49.0",
-        "@lexical/extension": "0.49.0",
-        "@lexical/selection": "0.49.0",
-        "@lexical/utils": "0.49.0",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/selection": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.49.0.tgz",
-      "integrity": "sha512-08Vd1+VoC6YnztWOFWVsqF/Hxw5EP8qeL1c7t3+rVCV8revLzXxdQw+vbPX3tgM4fmjOBDUXk6Ws1+rTtsqjcQ==",
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.2.1.tgz",
+      "integrity": "sha512-K+cGUL5iBcDqxmsocrjmlASqDf24gc7artbVW3PewG2c9AqwC63lezgwvB85Nx4lZAQjB6zIFHh9A7t1yGbwhw==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/internal": "0.49.0",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/text": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.49.0.tgz",
-      "integrity": "sha512-mowedvbvx0HDaW+ymVdYmWVhueqgauhhqIWaCtbJj33tPk8pOu1BB0pZuJQbOB+1bDnFiZhkJV8W/CvR2M9lEA==",
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.2.1.tgz",
+      "integrity": "sha512-rxj6UYjU1qd98gxNQOSCdLpc5cPRi5Giq9rNd3jnGuSNIyMkwa6Dxw4cUjmhIBCYESMJtmNt5NWnJp5u9wTfYQ==",
+      "cpu": [
+        "ia32"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/internal": "0.49.0",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
     },
-    "node_modules/@lexical/utils": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.49.0.tgz",
-      "integrity": "sha512-Jaa6DERBqxiFOFa49VPRV1WOb7mzRbMZ5U+v+RFagjzTmBhfxDmEkbQQ9nYTU3n3DPfdT8Hkyffextmw04etXg==",
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.2.1.tgz",
+      "integrity": "sha512-aHhnHzkPRmT/IHDlGvESJ/Bs32m8N6UE6Ab6kMeJzgk74IN8af2m/81/wZJtybR1M2UxCV4NmlVNUYQQvSAO3Q==",
+      "cpu": [
+        "loong64"
+      ],
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@lexical/internal": "0.49.0",
-        "@lexical/selection": "0.49.0",
-        "lexical": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
       }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.2.1.tgz",
+      "integrity": "sha512-qtQBsjbm3LiirLJvajWmKkNb7ARk7fvJVXdftJ7NtAnF3Xw8EbDvrtvmvtNI1yLPlYcBmlzCCD71hwhWYk0SIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.2.1.tgz",
+      "integrity": "sha512-c7hw7Qs/r5gnFRTQLcbifBwRU7wiocj+2pVuDQ5Ahb3r36SZmupmgYbTWcLvTW+hul1jd7SKRV0d14ZJq/tvSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.2.1.tgz",
+      "integrity": "sha512-mmY8fY8LQ/CB52+h3yrMYmVyoxzW3x08S0yI6VNfHWdfU6yJtZkKCbhjmQCYMrWbYKC4gMvwZwCywIGPAkLyeA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.2.1.tgz",
+      "integrity": "sha512-k4ig6aAPbFSRATOIIOfdf/KtlOGH4SVls6L9fy0QnTxRJYvY2oSltTsQtBDANgEQldlq8Kl5WnpRa1VSibP4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.2.1.tgz",
+      "integrity": "sha512-cTWBJGK//pDMeKQJE/79Aq9MiOAF4H8QyLZHSQ9IWm8czOfwjG4J1AhsQ9DjI9KFOykH77hhnpmQTGVMIubGig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.2.1.tgz",
+      "integrity": "sha512-Z50EM6TAZ7CFyMmyX6thv8eNpJchqe9eenhibSIy2Eq/FQYF76gU2VK/LEoaF46L8hfC7TpTp9b10MvReHEyFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.2.1.tgz",
+      "integrity": "sha512-ZmZNiBO6bkOSh3QNzgfvb1cMY0yMobn6ZQrSMqbAce21qyYL8niIbyipz9N/PIRDciGhsV0wUxnZsxIO+yWsHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/ext-apps": {
       "version": "1.7.5",
@@ -1189,16 +6394,395 @@
         "node": "^22.20 || ^24.12 || >=25"
       }
     },
-    "node_modules/@preact/signals-core": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
-      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+    "node_modules/@octokit/openapi-types": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-29.0.1.tgz",
+      "integrity": "sha512-9qWOMFNxxLokERcms42rU0PTLqQmVs7g5E41TI4mCOxmpFayD1rfC7XxOL55cG9MBZLFlC31BrR37myMKardwg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/openapi-webhooks-types": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-12.1.0.tgz",
+      "integrity": "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.2.tgz",
+      "integrity": "sha512-XZRuT3xZ84D3gYErI1DZvhJ33dCWVV6uzBtWkaBB4TvA/L6eOeTZodxLFVB44bBEEo3vEx7y00UfX1tBLrtLRg==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
+      "dependencies": {
+        "@octokit/types": "^18.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
+    },
+    "node_modules/@octokit/types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-18.0.0.tgz",
+      "integrity": "sha512-l6bAF43PNxkJp6g+W4PjoUSSkxHomXw2nOum5CTftJz1NlV3vu93NImgOYtLf6CbBUb5j+fiuzW0PPQ5JTSvZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^29.0.1"
+      }
+    },
+    "node_modules/@octokit/webhooks": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-14.2.0.tgz",
+      "integrity": "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-webhooks-types": "12.1.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/webhooks-methods": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/webhooks-methods": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-6.0.0.tgz",
+      "integrity": "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.220.0.tgz",
+      "integrity": "sha512-8186thl+pTw64iz/qEEen5oJZoZ/gO73XruChdaGlYdWOdBIQ42r+vHLf6a7vIDqTD4b8ZOoMlyxptanECaI9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0",
+        "@opentelemetry/sdk-logs": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-transformer": "0.220.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-logs": "0.220.0",
+        "@opentelemetry/sdk-metrics": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.4",
@@ -1550,6 +7134,141 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/core": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.34.0.tgz",
+      "integrity": "sha512-YvlfAEyHmuWpwjEKgq4FBaXhLEoSEwS/nNbyCF/ef05ZvSuwMDB4NIMgXqkJojzYyQWjhVDapPHXfhkz/tZYlg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1601,10 +7320,10 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1723,6 +7442,205 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1747,6 +7665,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1788,6 +7716,13 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1831,6 +7766,16 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bindings": {
@@ -1890,6 +7835,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1912,6 +7864,29 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bundle-require": {
@@ -2027,16 +8002,6 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2045,6 +8010,70 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.2.tgz",
+      "integrity": "sha512-o8vI5RE5A6EVVOd9o41jKp41aJom+QTEO/Bx8MYNjexMo/Bv2WOjUfZr+aL0WnYSgymUy6zeguqLTsIhV0gMvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "destroy": "1.2.0",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/confbox": {
@@ -2168,6 +8197,16 @@
         "cytoscape": "^3.2.0"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2219,6 +8258,49 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2228,6 +8310,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2235,6 +8328,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotparser": {
@@ -2255,6 +8358,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -2487,11 +8600,25 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.7",
@@ -2526,6 +8653,37 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
@@ -2564,6 +8722,19 @@
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -2614,6 +8785,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2656,6 +8857,34 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -2720,6 +8949,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -2788,11 +9045,75 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2826,6 +9147,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -2838,30 +9206,66 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.2.1.tgz",
+      "integrity": "sha512-0qE3lZ8jllRqPN4Ob6Ajl7c2bJSJDhQWuKLGP5hIEpHLllJWv1ydHFMhHmHc5p/W9GticKVDbYzZd7TBoQ4CZg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-android-arm64": "3.2.1",
+        "@koromix/koffi-android-x64": "3.2.1",
+        "@koromix/koffi-darwin-arm64": "3.2.1",
+        "@koromix/koffi-darwin-x64": "3.2.1",
+        "@koromix/koffi-freebsd-arm64": "3.2.1",
+        "@koromix/koffi-freebsd-ia32": "3.2.1",
+        "@koromix/koffi-freebsd-x64": "3.2.1",
+        "@koromix/koffi-linux-arm": "3.2.1",
+        "@koromix/koffi-linux-arm64": "3.2.1",
+        "@koromix/koffi-linux-ia32": "3.2.1",
+        "@koromix/koffi-linux-loong64": "3.2.1",
+        "@koromix/koffi-linux-riscv64": "3.2.1",
+        "@koromix/koffi-linux-x64": "3.2.1",
+        "@koromix/koffi-openbsd-ia32": "3.2.1",
+        "@koromix/koffi-openbsd-x64": "3.2.1",
+        "@koromix/koffi-win32-arm64": "3.2.1",
+        "@koromix/koffi-win32-ia32": "3.2.1",
+        "@koromix/koffi-win32-x64": "3.2.1"
+      }
+    },
     "node_modules/layout-base": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
       "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lexical": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.49.0.tgz",
-      "integrity": "sha512-9V1ZIzGpJEd8rIN+nN7veL4fW4fFWbS66Un4JNqSZB4D5t9euzN9+3+jEXy83FjNjNy0MiiUI3+DQaGCLYko0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/internal": "0.49.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.2"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -2892,6 +9296,13 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -3125,6 +9536,236 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-addon-native-custom-loader": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-native-custom-loader/-/node-addon-native-custom-loader-0.1.5.tgz",
+      "integrity": "sha512-rL0XXRytayIChYf1xaG9/1NzGBRTyFkQTIpn+MDz/hpr0PZw1a9PZIoH9HlYfagNawhXU+jfN650EvoSIvR7Vw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin/-/node-addon-require-builtin-0.1.5.tgz",
+      "integrity": "sha512-isaquiStlp7qdFpaffy+2ssJPUR/kLPRE5gqfeWbb0Ahph9H7O3BOFwThqkVaTrxfpnjrQauxlOEgvzD+snhUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "node-addon-require-builtin-darwin-arm64": "0.1.5",
+        "node-addon-require-builtin-darwin-x64": "0.1.5",
+        "node-addon-require-builtin-linux-arm64-gnu": "0.1.5",
+        "node-addon-require-builtin-linux-x64-gnu": "0.1.5",
+        "node-addon-require-builtin-win32-arm64-msvc": "0.1.5",
+        "node-addon-require-builtin-win32-ia32-msvc": "0.1.5",
+        "node-addon-require-builtin-win32-x64-msvc": "0.1.5"
+      }
+    },
+    "node_modules/node-addon-require-builtin-darwin-arm64": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-darwin-arm64/-/node-addon-require-builtin-darwin-arm64-0.1.5.tgz",
+      "integrity": "sha512-MZ5RyGhuU7DTbwuNpOQW81/ep8n5Yd5YlZa6dWiEfJEh+01Dl4cCKGmMCWNgb0VtqAImRtAOtmZIPtwngiemKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-darwin-x64": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-darwin-x64/-/node-addon-require-builtin-darwin-x64-0.1.5.tgz",
+      "integrity": "sha512-wdCSPn49AdNZ2EXHQqswiXk1cROFe9zSRaAX8PwQLxmjdLt+xZF7vZP6VlqgXm+VAOHv98q8kp9m7mO9jY3OgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-linux-arm64-gnu": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-linux-arm64-gnu/-/node-addon-require-builtin-linux-arm64-gnu-0.1.5.tgz",
+      "integrity": "sha512-hCqzKpQiknDDv6rUdZqrxCBXROg/uUruO0geUuZsdM9M/Lds45gSb4bDE958HlPaCvrDyR0wTHl3II8A7yQeew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-linux-x64-gnu": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-linux-x64-gnu/-/node-addon-require-builtin-linux-x64-gnu-0.1.5.tgz",
+      "integrity": "sha512-lgP+ruwWXbcXDslhp5uIc+dFgzITEGPZ4E50WdHGt/OzcoVhN6y5z72pRRvxy8DE661//QxqmCLe72rS3SVg+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-win32-arm64-msvc": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-arm64-msvc/-/node-addon-require-builtin-win32-arm64-msvc-0.1.5.tgz",
+      "integrity": "sha512-KEO2eWS4lvZg6JmPPz04OdI4Ojrc7YzOs++4r6VnvwsqYN2r6mjGSGpouQkk8J2eLXBzC7X/D9wYTbUuQS8u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-addon-require-builtin-win32-ia32-msvc": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-ia32-msvc/-/node-addon-require-builtin-win32-ia32-msvc-0.1.5.tgz",
+      "integrity": "sha512-iSC988EqZm5XbKWp/giW6K6EBRTrHt/YQbAkKsZLglt7PplmvvrZ7C3tUsyh1wVxUTYAaxFdE2xbqSdpw0rb6g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20 <23"
+      }
+    },
+    "node_modules/node-addon-require-builtin-win32-x64-msvc": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/node-addon-require-builtin-win32-x64-msvc/-/node-addon-require-builtin-win32-x64-msvc-0.1.5.tgz",
+      "integrity": "sha512-pjuco/ESU3ChIp7WwacWfY2ENu2K5rGAgqjcXedoiFcTrjTf5Ln/miKSuNfE6IiuJ7tfMTJH6VH5hq+C1Y8JMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "node-addon-native-custom-loader": "0.1.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.2.0-beta.15",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.15.tgz",
+      "integrity": "sha512-vORSzHXi4Ofl7HemVWpuudLqCPdaQb4LfpRCUpE5HPxhp4JYscl8zZwxh11p26v2wvW24WMwnMfLjhRLixrfxA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3158,6 +9799,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3165,6 +9816,60 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.3.tgz",
+      "integrity": "sha512-b3souUgU0VaAvMmzA4+9cRgrOgMdE0vc9H9VhQ0FYnjjcyZ8R/f9DiwMU9V8rl+vjf05On9UJhbgb06fsTs87Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.5.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.2.1",
+        "wsl-utils": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/parseurl": {
@@ -3175,6 +9880,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -3335,6 +10047,19 @@
         }
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+      "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -3360,6 +10085,30 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -3491,6 +10240,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
@@ -3551,6 +10320,19 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-buffer": {
@@ -3641,6 +10423,56 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3813,6 +10645,17 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -4019,12 +10862,26 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -4575,6 +11432,20 @@
         "node": "*"
       }
     },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -4606,6 +11477,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4626,6 +11504,16 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -4829,6 +11717,16 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4866,6 +11764,74 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "stratagate-dsh",
-  "version": "0.2.55",
+  "version": "0.2.64",
   "description": "Recent conversations stay vivid. Older ones fade into summaries, not oblivion. StrataGate gives DeepSeek Harness six-layer, time-decaying memory, while lasting events and relationships settle into a knowledge graph. Bring your memories from other AIs with you—no need to start over.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "stratagate-dsh-repair": "./dist/repair-profile.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -55,7 +58,7 @@
     "test:dsh": "vitest run --config vitest.config.ts",
     "test:core": "npm run test --workspace @diqier/stratagate",
     "test:workbuddy": "npm run test --workspace stratagate-workbuddy",
-    "verify:dsh": "npm run build:dsh && node scripts/verify-package.mjs",
+    "verify:dsh": "npm run build:dsh && node scripts/verify-package.mjs && npm pack --ignore-scripts --pack-destination . && node scripts/verify-dsh-install.mjs stratagate-dsh-0.2.64.tgz",
     "verify:workbuddy": "npm run verify:package --workspace stratagate-workbuddy",
     "test:watch": "vitest --config vitest.config.ts",
     "prepare": "npm run build:dsh"
@@ -111,7 +114,8 @@
     },
     "compatibility": {
       "dshVersions": [
-        "0.1.2-rc.1"
+        "0.1.2-rc.1",
+        "0.1.5-rc.1"
       ]
     },
     "permissions": [
@@ -144,26 +148,71 @@
     "node": "^22.19.0 || >=24.0.0"
   },
   "peerDependencies": {
-    "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-agent-default-model": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-client-ui-conversation": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-llm": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-session": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-settings": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-system-prompt": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/dsh-tools": ">=0.1.2-rc.1 <0.2.0",
-    "@deepseek-ai/schemastery": "^3.18.1"
+    "@deepseek-ai/cordis": "4.0.2",
+    "@deepseek-ai/dsh-agent-default-model": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-client-ui-conversation": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-llm": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-session": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format-catalog": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format-v0-to-v1": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-settings": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/dsh-tools": "0.1.2-rc.1 || 0.1.5-rc.2",
+    "@deepseek-ai/schemastery": "3.18.2"
+  },
+  "peerDependenciesMeta": {
+    "@deepseek-ai/cordis": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-agent-default-model": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-client-ui-conversation": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-llm": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-session": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-session-format": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-session-format-catalog": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-session-format-v0-to-v1": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-settings": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-system-prompt": {
+      "optional": true
+    },
+    "@deepseek-ai/dsh-tools": {
+      "optional": true
+    },
+    "@deepseek-ai/schemastery": {
+      "optional": true
+    }
   },
   "devDependencies": {
-    "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-agent-default-model": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-client-ui-conversation": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-llm": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-session": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-settings": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-system-prompt": "0.1.2-rc.1",
-    "@deepseek-ai/dsh-tools": "0.1.2-rc.1",
-    "@deepseek-ai/schemastery": "^3.18.1",
+    "@deepseek-ai/cordis": "4.0.2",
+    "@deepseek-ai/dsh": "0.1.5-rc.1",
+    "@deepseek-ai/dsh-agent-default-model": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-client-ui-conversation": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-llm": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format-catalog": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-session-format-v0-to-v1": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-settings": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-system-prompt": "0.1.5-rc.2",
+    "@deepseek-ai/dsh-tools": "0.1.5-rc.2",
+    "@deepseek-ai/schemastery": "3.18.2",
     "@types/node": "^22.0.0",
     "cytoscape": "^3.34.1",
     "cytoscape-fcose": "^2.2.0",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -234,6 +234,7 @@ export class StrataGate {
   private readonly summaryJobs = new Map<string, BlockSummaryJob>();
   private readonly elementProjectionJobs = new Map<string, ElementProjectionJob>();
   private readonly graphProjectionJobs = new Map<string, GraphProjectionJob>();
+  private readonly manualRetryRuns = new Map<string, Promise<unknown>>();
   private readonly usageReceipts = new Map<string, UsageReceipt>();
   private readonly successfulModelResponses: SuccessfulModelResponse[] = [];
   private readonly ingestionReceipts = new Map<string, IngestionReceipt>();
@@ -499,6 +500,95 @@ export class StrataGate {
 
   listSummaryJobs(): readonly BlockSummaryJob[] {
     return [...this.summaryJobs.values()];
+  }
+
+  private runManualRetry<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const existing = this.manualRetryRuns.get(key) as Promise<T> | undefined;
+    if (existing) return existing;
+    const run = operation().finally(() => {
+      if (this.manualRetryRuns.get(key) === run) this.manualRetryRuns.delete(key);
+    });
+    this.manualRetryRuns.set(key, run);
+    return run;
+  }
+
+  /** Give one failed Block Summary job a fresh, user-requested retry budget. */
+  async retryBlockSummary(id: string): Promise<ResumePendingResult> {
+    const blockId = id.trim();
+    if (!blockId) throw new TypeError('Block id must not be empty');
+    return this.runManualRetry(`summary:${blockId}`, async () => {
+      const block = this.blocks.find((candidate) => candidate.id === blockId);
+      if (!block) throw new Error(`Unknown block: ${blockId}`);
+      if (block.processingStatus !== 'pending') throw new Error(`Block ${blockId} is already ready`);
+      await this.commitMutation(() => {
+        const job = this.summaryJobs.get(blockId);
+        if (!job) throw new Error(`Missing summary job for block: ${blockId}`);
+        if (job.status !== 'failed') throw new Error(`Block ${blockId} Summary is ${job.status}, not failed`);
+        this.summaryJobs.set(blockId, {
+          ...job,
+          status: 'pending',
+          attempts: 0,
+          lastError: null,
+          nextRetryAt: null,
+          updatedAt: toUtc8Iso(this.now()),
+        });
+      });
+      const extractedEvents = await this.processBlock(block, { retryFailed: false });
+      const processed = this.blocks.find((candidate) => candidate.id === blockId);
+      const readyBlocks = processed?.processingStatus === 'ready' ? [processed] : [];
+      return { sealedBlocks: [], readyBlocks, extractedEvents, projectedElements: [] };
+    });
+  }
+
+  /** Retry only Event extraction for one failed Block without rerunning its Summary. */
+  async retryEventExtraction(id: string): Promise<EventCard[]> {
+    const blockId = id.trim();
+    if (!blockId) throw new TypeError('Block id must not be empty');
+    return this.runManualRetry(`extraction:${blockId}`, async () => {
+      const block = this.blocks.find((candidate) => candidate.id === blockId);
+      if (!block) throw new Error(`Unknown block: ${blockId}`);
+      if (block.processingStatus !== 'pending' || block.shouldExtract !== true) {
+        throw new Error(`Block ${blockId} is not waiting for Event extraction`);
+      }
+      await this.commitMutation(() => {
+        const job = this.extractionJobs.get(blockId);
+        if (!job) throw new Error(`Missing extraction job for block: ${blockId}`);
+        if (job.status !== 'failed') throw new Error(`Event extraction ${blockId} is ${job.status}, not failed`);
+        this.extractionJobs.set(blockId, {
+          ...job,
+          attempts: 0,
+          lastError: null,
+          nextRetryAt: null,
+          updatedAt: toUtc8Iso(this.now()),
+        });
+      });
+      return await this.extractEligibleBlock({ blockId, retryFailed: true }) ?? [];
+    });
+  }
+
+  /** Retry exactly one failed Graph projection batch. */
+  async retryGraphProjection(id: string): Promise<{ nodeIds: string[]; edgeIds: string[] }> {
+    const jobId = id.trim();
+    if (!jobId) throw new TypeError('Graph projection id must not be empty');
+    return this.runManualRetry(`graph:${jobId}`, async () => {
+      if (!this.graphProjector) throw new Error('Graph projector is not configured');
+      await this.commitMutation(() => {
+        const job = this.requireGraphProjectionJob(jobId);
+        if (job.status !== 'failed') throw new Error(`Graph projection ${jobId} is ${job.status}, not failed`);
+        job.status = 'pending';
+        job.attempts = 0;
+        job.lastError = null;
+        job.updatedAt = toUtc8Iso(this.now());
+      });
+      const batch = await this.claimGraphProjection(jobId);
+      if (!batch) throw new Error(`Graph projection ${jobId} could not be claimed`);
+      try {
+        return await this.completeGraphProjection(jobId, await this.graphProjector(batch));
+      } catch (error) {
+        await this.failGraphProjection(jobId, error);
+        throw error;
+      }
+    });
   }
 
   listElementProjectionJobs(): readonly ElementProjectionJob[] {
@@ -1251,10 +1341,11 @@ export class StrataGate {
     });
   }
 
-  async claimNextGraphProjection(): Promise<GraphProjectionContext | null> {
+  private async claimGraphProjection(jobId?: string): Promise<GraphProjectionContext | null> {
     return this.commitMutation(() => {
       const job = [...this.graphProjectionJobs.values()]
-        .filter((candidate) => candidate.status === 'pending' || candidate.status === 'failed')
+        .filter((candidate) => (jobId === undefined || candidate.id === jobId)
+          && (candidate.status === 'pending' || candidate.status === 'failed'))
         .sort((left, right) => right.priority - left.priority || left.createdAt.localeCompare(right.createdAt))[0];
       if (!job) return null;
       const events = job.sourceEventIds.flatMap((id) => this.events.find((event) => event.id === id) ?? []);
@@ -1279,6 +1370,10 @@ export class StrataGate {
         existingEdges: structuredClone(this.graphEdges.filter(({ fromNodeId, toNodeId }) => nodeIds.has(fromNodeId) && nodeIds.has(toNodeId)).slice(-120)),
       };
     });
+  }
+
+  async claimNextGraphProjection(): Promise<GraphProjectionContext | null> {
+    return this.claimGraphProjection();
   }
 
   async completeGraphProjection(jobId: string, result: GraphProjectionResult): Promise<{ nodeIds: string[]; edgeIds: string[] }> {

--- a/packages/core/tests/block-processing.test.ts
+++ b/packages/core/tests/block-processing.test.ts
@@ -100,4 +100,72 @@ describe('sealed Block processing boundary', () => {
       .toEqual(['one', 'saved', 'two', 'also saved']);
     expect(memory.exportSnapshot().ingestionReceipts.map(({ id }) => id)).toEqual(['turn:1', 'turn:2']);
   });
+
+  it('allows an explicit retry of one terminally failed Block Summary', async () => {
+    let shouldFail = true;
+    let calls = 0;
+    const memory = StrataGate.inMemory({
+      blockTurnSize: 1,
+      summarizer: async (messages) => {
+        calls += 1;
+        if (shouldFail) throw new Error('invalid API key');
+        return validSummary(messages);
+      },
+      extractor: async () => ({ shouldExtract: false, reason: 'none', events: [] }),
+    });
+
+    await memory.appendTurn({ user: 'retry me', assistant: 'saved', receiptId: 'turn:retry' });
+    await memory.resumePendingWork({ retryFailed: true });
+    await memory.resumePendingWork({ retryFailed: true });
+    expect(memory.listSummaryJobs()[0]).toMatchObject({ status: 'failed', attempts: 3, nextRetryAt: null });
+
+    shouldFail = false;
+    const blockId = memory.listBlocks()[0]!.id;
+    const result = await memory.retryBlockSummary(blockId);
+    expect(calls).toBe(4);
+    expect(result.readyBlocks).toMatchObject([{ id: blockId, processingStatus: 'ready' }]);
+    expect(memory.listSummaryJobs()[0]).toMatchObject({ status: 'succeeded', attempts: 1, lastError: null });
+    expect(memory.listExtractionJobs()[0]).toMatchObject({ status: 'skipped' });
+  });
+
+  it('retries only one failed Event extraction and coalesces concurrent requests', async () => {
+    let extractionCalls = 0;
+    let summaryCalls = 0;
+    let shouldFail = true;
+    const memory = StrataGate.inMemory({
+      blockTurnSize: 1,
+      summarizer: async (messages) => {
+        summaryCalls += 1;
+        return validSummary(messages);
+      },
+      extractor: async () => {
+        extractionCalls += 1;
+        if (shouldFail) throw new Error('structured model task timed out');
+        return { shouldExtract: false, reason: 'nothing durable', events: [] };
+      },
+    });
+
+    await memory.appendTurn({ user: 'extract me', assistant: 'saved' });
+    await memory.resumePendingWork({ retryFailed: true });
+    await memory.resumePendingWork({ retryFailed: true });
+    const blockId = memory.listBlocks()[0]!.id;
+    expect(memory.listExtractionJobs()[0]).toMatchObject({ status: 'failed', attempts: 3, nextRetryAt: null });
+
+    await expect(memory.retryEventExtraction(blockId)).rejects.toThrow('structured model task timed out');
+    expect(memory.listExtractionJobs()[0]).toMatchObject({
+      status: 'failed', attempts: 1, lastError: 'structured model task timed out',
+    });
+
+    shouldFail = false;
+    const [first, second] = await Promise.all([
+      memory.retryEventExtraction(blockId),
+      memory.retryEventExtraction(blockId),
+    ]);
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+    expect(summaryCalls).toBe(1);
+    expect(extractionCalls).toBe(5);
+    expect(memory.listBlocks()[0]).toMatchObject({ id: blockId, processingStatus: 'ready' });
+    expect(memory.listExtractionJobs()[0]).toMatchObject({ status: 'skipped', attempts: 1, lastError: null });
+  });
 });

--- a/packages/core/tests/graph.test.ts
+++ b/packages/core/tests/graph.test.ts
@@ -85,4 +85,37 @@ describe('Event-backed knowledge graph', () => {
     expect(attempts).toBe(2);
     await restored.close();
   });
+
+  it('manually retries only the selected failed Graph projection', async () => {
+    let shouldFail = true;
+    let calls = 0;
+    const memory = StrataGate.inMemory({
+      blockTurnSize: 1,
+      summarizer: async () => ({ l0Title: 'event', l0Tags: [], l1Summary: 'event', l2Keypoints: [], shouldExtract: true }),
+      extractor: async ({ target }) => ({
+        shouldExtract: true,
+        reason: 'event',
+        events: [{ title: 'Graph retry', summary: 'Retry this graph batch.', sourceMessageIds: [target.l5Raw[0]!.id], sourceBlockId: target.id }],
+      }),
+      graphProjector: async () => {
+        calls += 1;
+        if (shouldFail) throw new Error('graph timed out');
+        return { reason: 'completed', nodes: [], edges: [] };
+      },
+    });
+
+    await memory.appendTurn({ user: 'graph', assistant: 'saved' });
+    const jobId = memory.listGraphProjectionJobs()[0]!.id;
+    expect(memory.listGraphProjectionJobs()[0]).toMatchObject({ status: 'failed', attempts: 1 });
+
+    shouldFail = false;
+    const [first, second] = await Promise.all([
+      memory.retryGraphProjection(jobId),
+      memory.retryGraphProjection(jobId),
+    ]);
+    expect(first).toEqual({ nodeIds: [], edgeIds: [] });
+    expect(second).toEqual(first);
+    expect(calls).toBe(2);
+    expect(memory.listGraphProjectionJobs()[0]).toMatchObject({ id: jobId, status: 'completed', attempts: 1, lastError: null });
+  });
 });

--- a/scripts/build-client.mjs
+++ b/scripts/build-client.mjs
@@ -31,3 +31,4 @@ writeFileSync(
   bundledClient.replace('__STRATAGATE_MASCOT_DATA_URL__', `data:image/png;base64,${mascot}`),
 )
 copyFileSync(new URL('src/client.d.ts', root), new URL('dist/client.d.ts', root))
+copyFileSync(new URL('dist/plugin.d.ts', root), new URL('dist/index.d.ts', root))

--- a/scripts/verify-dsh-install.mjs
+++ b/scripts/verify-dsh-install.mjs
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -30,6 +30,11 @@ function assert(condition, message) {
   if (!condition) throw new Error(message)
 }
 
+function platformFixture(source) {
+  const cwd = process.platform === 'win32' ? 'C:\\redacted\\workspace' : '/redacted/workspace'
+  return source.replace(/("cwd":)"[^"]*"/, `$1${JSON.stringify(cwd)}`)
+}
+
 function seedSessions(dshHome) {
   const project = join(dshHome, 'sessions', '--C-redacted-workspace--')
   const fixtures = [
@@ -39,7 +44,8 @@ function seedSessions(dshHome) {
   for (const [fixture, id] of fixtures) {
     const directory = join(project, id)
     mkdirSync(directory, { recursive: true })
-    copyFileSync(join(fixtureRoot, fixture, 'session.jsonl'), join(directory, 'session.jsonl'))
+    const source = readFileSync(join(fixtureRoot, fixture, 'session.jsonl'), 'utf8')
+    writeFileSync(join(directory, 'session.jsonl'), platformFixture(source))
   }
 }
 

--- a/scripts/verify-dsh-install.mjs
+++ b/scripts/verify-dsh-install.mjs
@@ -9,7 +9,9 @@ import { once } from 'node:events'
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 const tarball = process.argv[2] ? resolve(packageRoot, process.argv[2]) : join(packageRoot, 'stratagate-dsh-0.2.64.tgz')
-const versions = ['0.1.2-rc.1', '0.1.5-rc.1']
+const versions = process.env.DSH_VERSION
+  ? [process.env.DSH_VERSION]
+  : ['0.1.2-rc.1', '0.1.5-rc.1']
 const fixtureRoot = join(packageRoot, 'tests', 'fixtures')
 
 function run(command, args, cwd, env = {}) {
@@ -36,7 +38,8 @@ function platformFixture(source) {
 }
 
 function seedSessions(dshHome) {
-  const project = join(dshHome, 'sessions', '--C-redacted-workspace--')
+  const projectId = process.platform === 'win32' ? '--C-redacted-workspace--' : '--redacted-workspace--'
+  const project = join(dshHome, 'sessions', projectId)
   const fixtures = [
     ['legacy-session-v0', 'fixture-legacy-citations'],
     ['clean-session-v0', 'fixture-clean-session'],
@@ -186,7 +189,8 @@ try {
     const config = run(process.execPath, [cli, '--profile', 'web', '--dump-config'], root, dshEnv)
     assert(config.includes("sessionRoot: !!js dshHomePath('sessions')"), `${version}: sessionRoot was not wired to the host DSH_HOME`)
     await smokeWeb(cli, root, dshEnv, version)
-    const legacyDirectory = join(dshHome, 'sessions', '--C-redacted-workspace--', 'fixture-legacy-citations')
+    const projectId = process.platform === 'win32' ? '--C-redacted-workspace--' : '--redacted-workspace--'
+    const legacyDirectory = join(dshHome, 'sessions', projectId, 'fixture-legacy-citations')
     assert(existsSync(join(legacyDirectory, 'session.jsonl')), `${version}: immutable v0 fixture was removed`)
     if (version === '0.1.5-rc.1') {
       assert(existsSync(join(legacyDirectory, 'session.v1.jsonl')), `${version}: legacy citation bridge was not published`)

--- a/scripts/verify-dsh-install.mjs
+++ b/scripts/verify-dsh-install.mjs
@@ -1,0 +1,193 @@
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawn, spawnSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { once } from 'node:events'
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const tarball = process.argv[2] ? resolve(packageRoot, process.argv[2]) : join(packageRoot, 'stratagate-dsh-0.2.64.tgz')
+const versions = ['0.1.2-rc.1', '0.1.5-rc.1']
+const fixtureRoot = join(packageRoot, 'tests', 'fixtures')
+
+function run(command, args, cwd, env = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    shell: process.platform === 'win32' && command === npm,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed in ${cwd}\n${result.stdout}\n${result.stderr}`)
+  }
+  return result.stdout
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+function seedSessions(dshHome) {
+  const project = join(dshHome, 'sessions', '--C-redacted-workspace--')
+  const fixtures = [
+    ['legacy-session-v0', 'fixture-legacy-citations'],
+    ['clean-session-v0', 'fixture-clean-session'],
+  ]
+  for (const [fixture, id] of fixtures) {
+    const directory = join(project, id)
+    mkdirSync(directory, { recursive: true })
+    copyFileSync(join(fixtureRoot, fixture, 'session.jsonl'), join(directory, 'session.jsonl'))
+  }
+}
+
+async function smokeWeb(cli, root, env, version) {
+  const output = []
+  const child = spawn(process.execPath, [cli, '--profile', 'web', '--port', '0', '--no-open'], {
+    cwd: root,
+    env: { ...process.env, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let timer
+  try {
+    const launchUrl = await new Promise((resolveReady, rejectReady) => {
+      const inspect = (chunk) => {
+        const text = chunk.toString()
+        output.push(text)
+        const match = output.join('').match(/https?:\/\/(?:127\.0\.0\.1|localhost):\d+\/?\?token=[A-Za-z0-9_-]+/)
+        if (match) resolveReady(match[0])
+      }
+      child.stdout.on('data', inspect)
+      child.stderr.on('data', inspect)
+      child.once('exit', (code) => rejectReady(new Error(`${version}: Web smoke exited ${code}\n${output.join('')}`)))
+      // A cold 0.1.5 profile can spend close to a minute materializing its
+      // generated browser graph on Windows CI before it prints the launch URL.
+      timer = setTimeout(() => rejectReady(new Error(`${version}: Web smoke timed out\n${output.join('')}`)), 120_000)
+    })
+    const origin = new URL(launchUrl).origin
+    const exchange = await fetch(launchUrl, { redirect: 'manual' })
+    assert(exchange.status === 303, `${version}: launch-token exchange returned HTTP ${exchange.status}`)
+    const cookie = exchange.headers.get('set-cookie')?.split(';', 1)[0]
+    assert(cookie, `${version}: launch-token exchange did not mint a browser cookie`)
+    const response = await fetch(origin, { headers: { cookie } })
+    assert(response.ok, `${version}: Web shell returned HTTP ${response.status}`)
+    const html = await response.text()
+    assert(html.includes('__DSH_BOOT__'), `${version}: Web shell omitted the DSH boot payload`)
+
+    const call = async (method, args) => {
+      const rpcId = randomUUID()
+      const rpcResponse = await fetch(`${origin}/api/${method}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', cookie },
+        body: JSON.stringify({ type: 'client-request', rpcId, method, payload: { args } }),
+      })
+      assert(rpcResponse.ok, `${version}: ${method} returned HTTP ${rpcResponse.status}`)
+      const envelope = await rpcResponse.json()
+      assert(envelope.rpcId === rpcId, `${version}: ${method} returned a mismatched RPC id`)
+      assert(envelope.result?.ok === true, `${version}: ${method} failed: ${JSON.stringify(envelope.result?.error)}`)
+      return envelope.result.value
+    }
+
+    const listed = await call('session/list', { _request: {} })
+    const expected = [
+      ['fixture-legacy-citations', 13, 'Legacy citation fixture', 'Redacted assistant reply B'],
+      ['fixture-clean-session', 6, 'Clean fixture session', 'Clean session assistant reply'],
+    ]
+    for (const [sessionId, throughSeq, title, reply] of expected) {
+      const summary = listed.items.find(item => item.sessionId === sessionId)
+      assert(summary, `${version}: session/list omitted ${sessionId}`)
+      const projectedTitle = summary.projections?.values?.title
+      if (projectedTitle !== undefined) {
+        assert(projectedTitle === title, `${version}: ${sessionId} cached title projection was incorrect`)
+      }
+      const page = await call('session/page', {
+        request: { address: { kind: 'session', sessionId }, throughSeq, maxMessages: 50 },
+      })
+      const records = JSON.stringify(page.records)
+      // Cold profiles may omit optional projection hints and message-aligned
+      // pages intentionally exclude log-only title events. The fixture source
+      // is the durable title authority; when the Host exposes a hint, verify
+      // its exact value as well.
+      assert(projectedTitle === undefined || projectedTitle === title, `${version}: ${sessionId} cached title projection was incorrect`)
+      const fixtureTitle = readFileSync(join(fixtureRoot, sessionId === 'fixture-legacy-citations' ? 'legacy-session-v0' : 'clean-session-v0', 'session.jsonl'), 'utf8')
+      assert(fixtureTitle.includes(`\"title\":\"${title}\"`), `${version}: ${sessionId} fixture title was not retained`)
+      assert(records.includes(reply), `${version}: switching to ${sessionId} did not return its conversation body`)
+    }
+  } finally {
+    clearTimeout(timer)
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill()
+      await Promise.race([once(child, 'exit'), new Promise(resolve => setTimeout(resolve, 5_000))])
+    }
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL')
+      await once(child, 'exit')
+    }
+  }
+}
+
+assert(existsSync(tarball), `Tarball does not exist: ${tarball}`)
+const roots = []
+try {
+  for (const version of versions) {
+    const root = mkdtempSync(join(tmpdir(), `stratagate-dsh-${version.replaceAll('.', '_')}-`))
+    roots.push(root)
+    const dshHome = join(root, 'dsh-home')
+    seedSessions(dshHome)
+    run(npm, ['init', '--yes'], root)
+    // Install the CLI as a whole. Its package.json intentionally resolves the
+    // internal 0.1.5 packages to rc.2; do not replace that tree package-by-package.
+    run(npm, ['install', '--no-save', '--package-lock=false', `@deepseek-ai/dsh@${version}`], root)
+    const cli = join(root, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js')
+    assert(existsSync(cli), `DSH CLI ${version} was not installed`)
+
+    const dshEnv = { DSH_HOME: dshHome }
+    run(process.execPath, [cli, 'plugin', '--profile', 'web', 'add', tarball], root, dshEnv)
+    const profile = join(dshHome, 'profiles', 'web')
+    writeFileSync(join(profile, 'cordis.patch.yml'), [
+      '- id: session-persistence-jsonl',
+      "  name: '@deepseek-ai/dsh-session-persistence-jsonl'",
+      '  config:',
+      "    root: !!js dshHomePath('sessions')",
+      '    compression: none',
+      '',
+    ].join('\n'))
+    const profileManifest = JSON.parse(readFileSync(join(profile, 'package.json'), 'utf8'))
+    assert(Object.keys(profileManifest.dependencies ?? {}).join(',') === 'stratagate-dsh', `${version}: plugin dependency set was not isolated`)
+    assert(!existsSync(join(profile, 'node_modules', '@deepseek-ai')), `${version}: fresh install leaked DSH core packages into the profile`)
+
+    // Seed the exact failure shape reported by users. Pnpm intentionally does
+    // not delete unknown hoisted directories, so the package must ignore this
+    // stale peer without deleting user files or loading a second DSH runtime.
+    const stale = join(profile, 'node_modules', '@deepseek-ai', 'dsh-session')
+    mkdirSync(stale, { recursive: true })
+    const staleVersion = version === '0.1.5-rc.1' ? '0.1.2-rc.1' : '0.1.5-rc.2'
+    writeFileSync(join(stale, 'package.json'), JSON.stringify({ name: '@deepseek-ai/dsh-session', version: staleVersion }))
+
+    // A second add exercises an in-place upgrade with the existing lockfile and
+    // profile generation. The stale directory remains recoverable on disk, but
+    // the bootstrap resolver must force StrataGate onto the host-owned tree.
+    run(process.execPath, [cli, 'plugin', '--profile', 'web', 'add', tarball], root, dshEnv)
+    assert(existsSync(stale), `${version}: upgrade unexpectedly deleted the seeded legacy package`)
+    const repair = run(process.execPath, [cli, 'plugin', '--profile', 'web', 'exec', 'stratagate-dsh-repair'], root, dshEnv)
+    assert(repair.includes('Quarantined'), `${version}: profile repair did not report a quarantine`)
+    assert(!existsSync(stale), `${version}: profile repair left the stale DSH package active`)
+    const backups = join(profile, '.stratagate-runtime-backups')
+    assert(existsSync(backups), `${version}: profile repair did not create a recoverable backup`)
+
+    const config = run(process.execPath, [cli, '--profile', 'web', '--dump-config'], root, dshEnv)
+    assert(config.includes("sessionRoot: !!js dshHomePath('sessions')"), `${version}: sessionRoot was not wired to the host DSH_HOME`)
+    await smokeWeb(cli, root, dshEnv, version)
+    const legacyDirectory = join(dshHome, 'sessions', '--C-redacted-workspace--', 'fixture-legacy-citations')
+    assert(existsSync(join(legacyDirectory, 'session.jsonl')), `${version}: immutable v0 fixture was removed`)
+    if (version === '0.1.5-rc.1') {
+      assert(existsSync(join(legacyDirectory, 'session.v1.jsonl')), `${version}: legacy citation bridge was not published`)
+      assert(existsSync(join(legacyDirectory, 'stratagate-legacy-citations-v1.json')), `${version}: migration receipt was not published`)
+    }
+    console.log(`Verified DSH ${version}: complete CLI install, recoverable stale-peer repair, startup, two session titles/pages, and legacy migration.`)
+  }
+} finally {
+  for (const root of roots) rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 250 })
+}

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, rmSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 import { spawnSync } from 'node:child_process'
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
@@ -46,6 +46,8 @@ try {
     'LICENSE',
     'dist/index.js',
     'dist/index.d.ts',
+    'dist/plugin.js',
+    'dist/repair-profile.js',
     'dist/client.js',
     'dist/client.d.ts',
   ]
@@ -69,11 +71,10 @@ try {
   run(['install', tarball, '--ignore-scripts', '--package-lock=false'], installRoot)
   const installed = join(installRoot, 'node_modules', 'stratagate-dsh')
   for (const path of required) assert(existsSync(join(installed, path)), `Clean install is missing ${path}`)
-  const plugin = await import(pathToFileURL(join(installed, 'dist', 'index.js')).href)
-  assert(plugin.name === 'stratagate-memory', 'Installed package exports the wrong plugin name')
-  assert(typeof plugin.apply === 'function', 'Installed package does not export apply()')
-
-  console.log(`Verified ${packed.filename}: ${packed.entryCount} files, clean install and import passed.`)
+  // DSH core packages are optional peers and intentionally absent from this
+  // bare npm project. Runtime import is covered by verify-dsh-install.mjs,
+  // which installs the complete host CLI and its real dependency tree.
+  console.log(`Verified ${packed.filename}: ${packed.entryCount} files and clean tarball install passed.`)
 } finally {
   if (installRoot) rmSync(installRoot, { recursive: true, force: true })
   if (tarball) rmSync(tarball, { force: true })

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,19 @@
+import { installDshHostResolution } from './dsh-host-resolution.js'
+
+// DSH prepares its installation-owned module fallback before it imports a
+// profile bundle. Install the narrowly-scoped resolver first, then load the
+// implementation so stale profile-local peers cannot win ESM resolution.
+installDshHostResolution(import.meta.url)
+
+// This file and src/index.ts are separate tsup entries. The runtime path is
+// intentionally external so the implementation is instantiated only after
+// the resolver above is active.
+// @ts-expect-error dist/plugin.js is emitted from src/index.ts during build.
+const plugin = await import('./plugin.js') as typeof import('./index.js')
+
+export const name = plugin.name
+export const inject = plugin.inject
+export const STRATAGATE_SETTINGS_NAMESPACE = plugin.STRATAGATE_SETTINGS_NAMESPACE
+export const Config = plugin.Config
+export const apply = plugin.apply
+export type PluginConfig = import('./index.js').PluginConfig

--- a/src/client.js
+++ b/src/client.js
@@ -213,7 +213,7 @@ window.__ModuleLoader__.load({
       .sg-status{display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:5px;font-size:12px;font-weight:650}.sg-status:before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor}.sg-status.organized{color:var(--sg-good);background:var(--sg-good-soft)}.sg-status.processing{color:var(--sg-accent);background:var(--sg-accent-soft)}.sg-status.waiting{color:var(--sg-muted);background:var(--sg-soft)}.sg-status.failed{color:var(--sg-warn);background:var(--sg-warn-soft)}
       .sg-backbar{display:flex;align-items:center;min-height:35px;margin:-4px 0 13px}.sg-back{display:inline-flex;align-items:center;gap:6px;margin-left:-7px;padding:6px 7px;border-radius:6px;font-weight:650}.sg-detail-header{padding-bottom:16px;border-bottom:1px solid var(--sg-border)}.sg-detail-section{padding:18px 0;border-bottom:1px solid var(--sg-border)}.sg-detail-section:last-child{border-bottom:0}.sg-section-title{margin:0 0 11px;font-size:14px;font-weight:730}.sg-prose{margin:0;white-space:pre-wrap}.sg-facts{margin:0;padding-left:20px}.sg-facts li+li{margin-top:7px}.sg-related-list{display:flex;flex-direction:column}.sg-related{display:flex;justify-content:space-between;gap:12px;padding:9px 0;border:0;border-bottom:1px solid var(--sg-border);background:transparent;text-align:left;cursor:pointer}.sg-related:last-child{border-bottom:0}.sg-related-name{color:var(--sg-accent)}.sg-related-time{flex:0 0 auto;color:var(--sg-muted);font-size:12px}
       .sg-source-label{display:flex;align-items:center;gap:8px}.sg-source-icon{color:var(--sg-muted)}.sg-tech{margin-top:13px}.sg-tech summary{color:var(--sg-muted);font-size:12px;cursor:pointer}.sg-tech-body{margin-top:10px;padding:11px;border-radius:7px;background:var(--sg-soft);font-size:12px}.sg-tech-row{display:grid;grid-template-columns:88px minmax(0,1fr);gap:9px;padding:3px 0}.sg-code{font:12px/1.55 ui-monospace,SFMono-Regular,Consolas,monospace;white-space:pre-wrap;overflow-wrap:anywhere}.sg-raw-message{padding-top:10px;margin-top:10px;border-top:1px solid var(--sg-border)}
-      .sg-result-count{margin:0 0 9px;color:var(--sg-muted);font-size:12px}.sg-result-event{padding:8px 0;border-bottom:1px solid var(--sg-border)}.sg-result-event:last-child{border-bottom:0}.sg-pipeline{display:flex;flex-direction:column}.sg-stage{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:12px;padding:9px 0;border-bottom:1px solid var(--sg-border)}.sg-stage:last-child{border-bottom:0}.sg-stage-value{font-size:12px}.sg-stage-value.done{color:var(--sg-good)}.sg-stage-value.failed{color:var(--sg-danger)}.sg-stage-value.waiting{color:var(--sg-muted)}.sg-lambda-control{display:flex;align-items:center;justify-content:flex-end;gap:7px}.sg-number-input,.sg-effort-select{padding:4px 5px;border:1px solid var(--sg-border);border-radius:6px;background:var(--sg-surface)}.sg-number-input{width:82px;text-align:right}.sg-effort-button{padding:4px 6px;border:0;border-radius:5px;background:transparent;color:var(--sg-muted);cursor:pointer;font-size:12px}.sg-effort-button:hover{background:var(--sg-soft);color:var(--sg-accent)}.sg-setting-switch{position:relative;width:38px;height:22px;padding:0;border:1px solid var(--sg-border);border-radius:999px;background:var(--sg-soft);cursor:pointer}.sg-setting-switch:before{content:"";position:absolute;left:3px;top:3px;width:14px;height:14px;border-radius:50%;background:var(--sg-muted);transition:transform var(--sg-fast) var(--sg-ease),background-color var(--sg-fast) var(--sg-ease)}.sg-setting-switch[aria-checked="true"]{border-color:var(--sg-accent);background:var(--sg-accent)}.sg-setting-switch[aria-checked="true"]:before{background:#fff;transform:translateX(16px)}.sg-setting-switch:disabled{cursor:not-allowed;opacity:.5}.sg-setting-note{margin:7px 0 11px;color:var(--sg-muted);font-size:12px}.sg-setting-suggestion{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 10px;margin:4px 0 10px;border-radius:7px;background:var(--sg-soft);font-size:12px}.sg-save-button{align-self:flex-end;padding:7px 12px;margin-top:12px;border:0;border-radius:6px;background:var(--sg-accent);color:white;cursor:pointer}.sg-save-button:disabled{opacity:.5;cursor:not-allowed}.sg-safe-note{padding:11px 12px;margin-bottom:12px;border-radius:7px;background:var(--sg-good-soft);color:var(--sg-good);font-weight:650}.sg-error-note{margin:8px 0 0;color:var(--sg-muted);font-size:12px}
+      .sg-result-count{margin:0 0 9px;color:var(--sg-muted);font-size:12px}.sg-result-event{padding:8px 0;border-bottom:1px solid var(--sg-border)}.sg-result-event:last-child{border-bottom:0}.sg-pipeline{display:flex;flex-direction:column}.sg-stage{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:12px;padding:9px 0;border-bottom:1px solid var(--sg-border)}.sg-stage:last-child{border-bottom:0}.sg-stage-value{font-size:12px}.sg-stage-value.done{color:var(--sg-good)}.sg-stage-value.failed{color:var(--sg-danger)}.sg-stage-value.waiting{color:var(--sg-muted)}.sg-lambda-control{display:flex;align-items:center;justify-content:flex-end;gap:7px}.sg-number-input,.sg-effort-select{padding:4px 5px;border:1px solid var(--sg-border);border-radius:6px;background:var(--sg-surface)}.sg-number-input{width:82px;text-align:right}.sg-effort-button{padding:4px 6px;border:0;border-radius:5px;background:transparent;color:var(--sg-muted);cursor:pointer;font-size:12px}.sg-effort-button:hover{background:var(--sg-soft);color:var(--sg-accent)}.sg-setting-switch{position:relative;width:38px;height:22px;padding:0;border:1px solid var(--sg-border);border-radius:999px;background:var(--sg-soft);cursor:pointer}.sg-setting-switch:before{content:"";position:absolute;left:3px;top:3px;width:14px;height:14px;border-radius:50%;background:var(--sg-muted);transition:transform var(--sg-fast) var(--sg-ease),background-color var(--sg-fast) var(--sg-ease)}.sg-setting-switch[aria-checked="true"]{border-color:var(--sg-accent);background:var(--sg-accent)}.sg-setting-switch[aria-checked="true"]:before{background:#fff;transform:translateX(16px)}.sg-setting-switch:disabled{cursor:not-allowed;opacity:.5}.sg-setting-note{margin:7px 0 11px;color:var(--sg-muted);font-size:12px}.sg-setting-suggestion{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 10px;margin:4px 0 10px;border-radius:7px;background:var(--sg-soft);font-size:12px}.sg-save-button{align-self:flex-end;padding:7px 12px;margin-top:12px;border:0;border-radius:6px;background:var(--sg-accent);color:white;cursor:pointer}.sg-save-button:disabled{opacity:.5;cursor:not-allowed}.sg-safe-note{padding:11px 12px;margin-bottom:12px;border-radius:7px;background:var(--sg-good-soft);color:var(--sg-good);font-weight:650}.sg-error-note{margin:8px 0 0;color:var(--sg-muted);font-size:12px}.sg-job-list{display:grid;gap:10px}.sg-job{padding:12px;border:1px solid var(--sg-border);border-radius:7px;background:var(--sg-surface)}.sg-job-head{display:flex;align-items:flex-start;justify-content:space-between;gap:10px}.sg-job-title{margin:0;font-size:14px}.sg-job-meta{display:grid;grid-template-columns:112px minmax(0,1fr);gap:5px 10px;margin:11px 0;color:var(--sg-muted);font-size:12px}.sg-job-meta dd,.sg-job-meta dt{min-width:0;margin:0}.sg-job-meta dd{color:var(--sg-text);overflow-wrap:anywhere}.sg-job-error{max-height:150px;margin:9px 0;padding:9px;overflow:auto;border-radius:6px;background:var(--sg-danger-soft);color:var(--sg-danger)}.sg-job-actions{display:flex;align-items:center;justify-content:space-between;gap:10px}.sg-job-actions .sg-save-button{margin-top:0}.sg-status-feedback{margin:9px 0 0;color:var(--sg-muted);font-size:12px}.sg-status-feedback.failed{color:var(--sg-danger)}
       .sg-menu{display:grid;gap:7px}.sg-menu-row{display:grid;grid-template-columns:38px minmax(0,1fr) auto;align-items:center;gap:11px;width:100%;padding:12px;border:1px solid transparent;border-radius:10px;background:color-mix(in srgb,var(--sg-surface) 48%,transparent);text-align:left;cursor:pointer}.sg-menu-row:hover{border-color:color-mix(in srgb,var(--sg-accent) 22%,var(--sg-border));background:color-mix(in srgb,var(--sg-accent) 6%,var(--sg-surface));transform:translateY(-1px);box-shadow:0 8px 20px color-mix(in srgb,var(--sg-text) 6%,transparent)}.sg-menu-row:hover .sg-menu-title,.sg-menu-row:hover .sg-chevron{color:var(--sg-accent)}.sg-menu-icon{width:32px;height:32px;display:grid;place-items:center;border:1px solid color-mix(in srgb,var(--sg-accent) 14%,var(--sg-border));border-radius:8px;background:var(--sg-soft);color:var(--sg-muted);font-weight:700}.sg-menu-title{font-weight:700}.sg-menu-subtitle{color:var(--sg-muted);font-size:12px}.sg-counts{display:flex;gap:22px;padding:5px 0 18px;border-bottom:1px solid var(--sg-border)}.sg-count-value{font-size:22px;font-weight:760;letter-spacing:-.03em}.sg-count-label{color:var(--sg-muted);font-size:12px}.sg-structured-group{padding-top:17px}.sg-raw-group{padding:12px 0;border-bottom:1px solid var(--sg-border)}.sg-raw-group summary{cursor:pointer;font-weight:680}.sg-raw-json{max-height:360px;padding:11px;margin:10px 0 0;overflow:auto;border-radius:7px;background:var(--sg-soft)}
       .sg-import-card{padding:15px;border:1px solid color-mix(in srgb,var(--sg-accent) 22%,var(--sg-border));border-radius:11px;background:color-mix(in srgb,var(--sg-surface) 72%,transparent);box-shadow:0 8px 24px color-mix(in srgb,var(--sg-text) 5%,transparent)}.sg-import-card textarea{width:100%;min-height:270px;padding:11px;border:1px solid var(--sg-border);border-radius:8px;background:var(--sg-page);resize:vertical;outline:0;font:12px/1.55 ui-monospace,SFMono-Regular,Consolas,monospace}.sg-import-card textarea:focus{border-color:var(--sg-accent);box-shadow:0 0 0 3px var(--sg-focus)}.sg-import-actions{display:flex;align-items:center;gap:10px;margin-top:11px;flex-wrap:wrap}.sg-import-button{padding:8px 13px;border:1px solid var(--sg-accent);border-radius:7px;background:var(--sg-accent);color:#fff;cursor:pointer;font-weight:680}.sg-import-button:disabled{cursor:wait;opacity:.6}.sg-import-hint{margin:8px 0 0;color:var(--sg-muted);font-size:12px}.sg-import-result{margin-top:12px;padding:10px 11px;border-radius:7px;background:var(--sg-good-soft);color:var(--sg-good);font-size:12px}.sg-import-error{margin-top:12px;padding:10px 11px;border-radius:7px;background:var(--sg-danger-soft);color:var(--sg-danger);font-size:12px}
       .sg-import-overlay{position:fixed;inset:0;z-index:40;display:flex;align-items:center;justify-content:center;padding:18px;background:rgba(0,0,0,.52);backdrop-filter:blur(2px);animation:sg-view-in var(--sg-medium) var(--sg-ease) both}.sg-import-dialog{width:min(720px,calc(100vw - 28px));max-height:calc(100vh - 36px);overflow:auto;padding:14px;border:1px solid color-mix(in srgb,var(--sg-border) 90%,#fff 10%);border-radius:12px;background:var(--sg-page);box-shadow:0 24px 80px rgba(0,0,0,.42)}.sg-import-dialog-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:13px}.sg-import-dialog-title{margin:0;font-size:18px;font-weight:760}.sg-import-step{padding:12px;margin-top:10px;border-radius:9px;background:color-mix(in srgb,var(--sg-surface) 78%,transparent)}.sg-import-step-head{display:flex;align-items:center;gap:9px;margin-bottom:9px}.sg-import-step-num{display:grid;place-items:center;width:25px;height:25px;border-radius:50%;background:var(--sg-text);color:var(--sg-page);font-weight:760}.sg-import-step-title{font-weight:720}.sg-import-prompt{max-height:185px;padding:10px;overflow:auto;border-radius:7px;background:var(--sg-page);color:var(--sg-muted);font:12px/1.55 ui-monospace,SFMono-Regular,Consolas,monospace;white-space:pre-wrap}.sg-import-dialog .sg-import-card{padding:0;border:0;box-shadow:none;background:transparent}.sg-import-dialog .sg-import-card textarea{min-height:165px;background:var(--sg-page)}.sg-import-dialog-foot{display:flex;justify-content:flex-end;gap:9px;margin-top:14px}.sg-import-cancel{padding:8px 18px;border:1px solid var(--sg-border);border-radius:7px;background:transparent;cursor:pointer}.sg-import-dialog .sg-import-button{padding:8px 18px}.sg-import-copy{margin-left:auto;padding:6px 11px;border:1px solid var(--sg-border);border-radius:6px;background:var(--sg-page);cursor:pointer;font-size:12px}.sg-import-copy:hover{border-color:var(--sg-accent);color:var(--sg-accent)}.sg-import-loading{color:var(--sg-muted);font-size:12px}.sg-import-preview{display:grid;gap:8px;margin-top:10px}.sg-import-preview-item{padding:10px;border:1px solid var(--sg-border);border-radius:8px;background:var(--sg-page)}.sg-import-preview-title{font-weight:700}.sg-import-preview-meta{display:flex;gap:8px;margin-top:5px;color:var(--sg-muted);font-size:12px}.sg-import-preview-reason{margin-top:5px;font-size:12px}.sg-import-review{display:flex;gap:7px;align-items:flex-start;margin-top:8px;color:var(--sg-warn);font-size:12px}
@@ -1748,21 +1748,90 @@ window.__ModuleLoader__.load({
         h(SourceDetails, { item: element, source, kind: 'element' }))
     }
 
-    function ProcessingStatus({ overview, blocks, onBack, refresh }) {
+    function processingFingerprint(overview) {
+      return JSON.stringify({
+        failedJobs: Number(overview?.failedJobs || 0),
+        processingJobs: Number(overview?.processingJobs || 0),
+        failures: (overview?.failedJobDetails || []).map(({ kind, id, attempts, updatedAt, lastError }) => ({ kind, id, attempts, updatedAt, lastError })),
+      })
+    }
+
+    function ProcessingStatus({ overview, blocks, namespace, onBack, refresh }) {
       const failures = overview.failedJobDetails || []
-      const failedBlocks = blocks.filter((block) => block.status === 'failed')
-      const first = failures[0]
+      const [refreshing, setRefreshing] = React.useState(false)
+      const [feedback, setFeedback] = React.useState({ kind: '', text: '' })
+      const [retrying, setRetrying] = React.useState('')
+      const [retryErrors, setRetryErrors] = React.useState({})
+      const blockById = new Map(blocks.map((block) => [block.id, block]))
+      const taskLabel = (kind) => kind === 'block-summary' ? 'Block Summary' : kind === 'event-extraction' ? 'Event extraction' : 'Graph projection'
+      const retryKey = (job) => job.kind + ':' + job.id
+      const blockDescription = (job) => {
+        const details = Array.isArray(job.blockDetails) ? job.blockDetails : []
+        if (details.length) return details.map((block) =>
+          'Block ' + block.sequence + (block.title ? ' · ' + block.title : '')
+          + (Array.isArray(block.turnRange) ? '（第 ' + block.turnRange[0] + '–' + block.turnRange[1] + ' 轮）' : '')).join('；')
+        const ids = Array.isArray(job.blockIds) && job.blockIds.length ? job.blockIds : job.id && job.kind !== 'graph-projection' ? [job.id] : []
+        const labels = ids.map((id) => {
+          const block = blockById.get(id)
+          const sequence = block?.sequence ?? job.sequence
+          return (sequence ? 'Block ' + sequence : 'Block ' + String(id).slice(0, 10)) + (block?.title ? ' · ' + block.title : '')
+        })
+        return labels.length ? labels.join('；') : '关联 Block 不在当前分页中'
+      }
+      const conversationDescription = (job) => {
+        const ids = Array.isArray(job.threadIds) ? job.threadIds : job.threadId ? [job.threadId] : []
+        return ids.length ? ids.map((id) => String(id).slice(0, 16)).join('、') : '历史或未知对话'
+      }
+      const checkStatus = () => {
+        const before = processingFingerprint(overview)
+        setRefreshing(true)
+        setFeedback({ kind: '', text: '正在读取…' })
+        return refresh({ propagateError: true }).then((next) => {
+          const selected = next?.overview?.namespaces?.find((item) => item.namespace === namespace)
+          const changed = selected && processingFingerprint(selected) !== before
+          setFeedback({ kind: 'done', text: changed ? '状态已更新' : '状态没有变化' })
+        }).catch((reason) => {
+          setFeedback({ kind: 'failed', text: '读取失败：' + String(reason?.message || reason) })
+        }).finally(() => setRefreshing(false))
+      }
+      const retryJob = (job) => {
+        const key = retryKey(job)
+        setRetrying(key)
+        setRetryErrors((current) => ({ ...current, [key]: '' }))
+        setFeedback({ kind: '', text: taskLabel(job.kind) + ' 正在处理…' })
+        return api('jobs/retry', { namespace, kind: job.kind, jobId: job.id }, { method: 'POST' })
+          .then(() => refresh({ propagateError: true }))
+          .then(() => setFeedback({ kind: 'done', text: '任务已完成，状态已更新' }))
+          .catch(async (reason) => {
+            const message = String(reason?.message || reason)
+            setRetryErrors((current) => ({ ...current, [key]: message }))
+            setFeedback({ kind: 'failed', text: '重试失败：' + message })
+            try { await refresh({ propagateError: true }) } catch {}
+          })
+          .finally(() => setRetrying(''))
+      }
       return h(React.Fragment, null,
         h(BackBar, { label: '返回', onBack }),
         h('div', { className: 'sg-intro' }, h('h2', null, '处理状态'), h('p', null, failures.length + ' 个任务需要继续处理')),
         h('div', { className: 'sg-safe-note' }, '原始记忆已保存，不会丢失。'),
-        h('div', { className: 'sg-detail-section' }, h('div', { className: 'sg-pipeline' },
-          h('div', { className: 'sg-stage' }, h('span', null, '记忆保存'), h('span', { className: 'sg-stage-value done' }, '✓ 已完成')),
-          h('div', { className: 'sg-stage' }, h('span', null, '事件提取'), h('span', { className: 'sg-stage-value ' + (first?.kind === 'event-extraction' ? 'failed' : 'done') }, first?.kind === 'event-extraction' ? '× 失败' : '✓ 已完成')),
-          h('div', { className: 'sg-stage' }, h('span', null, '图谱投影'), h('span', { className: 'sg-stage-value ' + (first?.kind === 'graph-projection' ? 'failed' : first?.kind === 'event-extraction' ? 'waiting' : 'done') }, first?.kind === 'graph-projection' ? '× 失败' : first?.kind === 'event-extraction' ? '— 等待' : '✓ 已完成')))),
-        failedBlocks.length ? h('div', { className: 'sg-detail-section' }, h('h3', { className: 'sg-section-title' }, '受影响的短期记忆'), failedBlocks.map((block) => h('div', { key: block.id, className: 'sg-result-event' }, block.title || block.summary || '短期记忆'))) : null,
-        h('button', { className: 'sg-alert', onClick: refresh, style: { marginTop: '16px' } }, h('span', { className: 'sg-alert-mark' }, '↻'), h('span', null, h('span', { className: 'sg-alert-title' }, '重新检查状态'), h('br'), h('span', { className: 'sg-alert-copy' }, '任务会沿用现有重试机制继续处理。')), h('span', { className: 'sg-chevron' }, '›')),
-        h('details', { className: 'sg-tech' }, h('summary', null, '技术错误详情'), h('pre', { className: 'sg-tech-body sg-code' }, first?.lastErrorFull || first?.lastError || '没有记录技术错误。')))
+        failures.length ? h('div', { className: 'sg-job-list' }, failures.map((job) => {
+          const key = retryKey(job)
+          const busy = retrying === key
+          return h('section', { key, className: 'sg-job' },
+            h('div', { className: 'sg-job-head' }, h('h3', { className: 'sg-job-title' }, taskLabel(job.kind)), h('span', { className: 'sg-stage-value failed' }, '失败')),
+            h('dl', { className: 'sg-job-meta' },
+              h('dt', null, 'Block'), h('dd', null, blockDescription(job)),
+              h('dt', null, '对话'), h('dd', { className: 'sg-code' }, conversationDescription(job)),
+              h('dt', null, '当前尝试次数'), h('dd', null, String(job.attempts ?? 0)),
+              job.nextRetryAt ? h(React.Fragment, null, h('dt', null, '下次重试时间'), h('dd', null, formatTime(job.nextRetryAt))) : null),
+            h('div', { className: 'sg-muted', style: { fontSize: '12px' } }, '最近一次错误'),
+            h('pre', { className: 'sg-job-error sg-code' }, job.lastErrorFull || job.lastError || '没有记录技术错误。'),
+            h('div', { className: 'sg-job-actions' },
+              h('span', { className: 'sg-status-feedback failed', role: retryErrors[key] ? 'alert' : undefined }, retryErrors[key] || ''),
+              h('button', { type: 'button', className: 'sg-save-button', disabled: busy, onClick: () => void retryJob(job) }, busy ? '正在处理…' : '重试此任务')))
+        })) : h('div', { className: 'sg-safe-note' }, '当前没有失败任务。'),
+        h('button', { type: 'button', className: 'sg-alert', disabled: refreshing, onClick: () => void checkStatus(), style: { marginTop: '16px' } }, h('span', { className: refreshing ? 'sg-processing-icon' : 'sg-alert-mark' }, '↻'), h('span', null, h('span', { className: 'sg-alert-title' }, refreshing ? '正在读取…' : '重新检查状态'), h('br'), h('span', { className: 'sg-alert-copy' }, '只读取最新状态，不会触发模型调用。')), h('span', { className: 'sg-chevron' }, '›')),
+        feedback.text ? h('p', { className: 'sg-status-feedback ' + feedback.kind, role: feedback.kind === 'failed' ? 'alert' : 'status' }, feedback.text) : null)
     }
 
     function ImportPage({ namespace, onBack, refresh }) {
@@ -2337,8 +2406,21 @@ window.__ModuleLoader__.load({
 
     function SystemPage({ selected, blocks, onBack, refresh }) {
       const processing = blocks.filter((block) => block.status === 'processing').length
+      const [refreshing, setRefreshing] = React.useState(false)
+      const [feedback, setFeedback] = React.useState({ kind: '', text: '' })
+      const checkStatus = () => {
+        const before = processingFingerprint(selected)
+        setRefreshing(true)
+        setFeedback({ kind: '', text: '正在读取…' })
+        return refresh({ propagateError: true }).then((next) => {
+          const updated = next?.overview?.namespaces?.find((item) => item.namespace === selected.namespace)
+          setFeedback({ kind: 'done', text: updated && processingFingerprint(updated) !== before ? '状态已更新' : '状态没有变化' })
+        }).catch((reason) => {
+          setFeedback({ kind: 'failed', text: '读取失败：' + String(reason?.message || reason) })
+        }).finally(() => setRefreshing(false))
+      }
       return h(React.Fragment, null, h(BackBar, { label: '更多', onBack }), h('div', { className: 'sg-intro' }, h('h2', null, '系统状态'), h('p', null, '仅在这里展示记忆处理的工程状态')), h('div', { className: 'sg-pipeline' },
-        [['Block 数量', selected.blocks], ['待处理任务', processing], ['失败任务', selected.failedJobs], ['最近整理时间', formatTime(selected.lastActivityAt)], ['Event 提取', selected.failedJobDetails?.some((item) => item.kind === 'event-extraction') ? '有失败' : '正常'], ['图谱投影', selected.failedJobDetails?.some((item) => item.kind === 'graph-projection') ? '有失败' : '正常']].map(([label, value]) => h('div', { key: label, className: 'sg-stage' }, h('span', null, label), h('span', { className: 'sg-stage-value ' + (label === '失败任务' && value ? 'failed' : 'waiting') }, String(value))))), h('button', { className: 'sg-quiet-button', onClick: refresh, style: { marginTop: '14px' } }, '↻ 重新检查'))
+        [['Block 数量', selected.blocks], ['待处理任务', processing], ['失败任务', selected.failedJobs], ['最近整理时间', formatTime(selected.lastActivityAt)], ['Event 提取', selected.failedJobDetails?.some((item) => item.kind === 'event-extraction') ? '有失败' : '正常'], ['图谱投影', selected.failedJobDetails?.some((item) => item.kind === 'graph-projection') ? '有失败' : '正常']].map(([label, value]) => h('div', { key: label, className: 'sg-stage' }, h('span', null, label), h('span', { className: 'sg-stage-value ' + (label === '失败任务' && value ? 'failed' : 'waiting') }, String(value))))), h('button', { type: 'button', className: 'sg-quiet-button', disabled: refreshing, onClick: () => void checkStatus(), style: { marginTop: '14px' } }, refreshing ? '↻ 正在读取…' : '↻ 重新检查'), feedback.text ? h('p', { className: 'sg-status-feedback ' + feedback.kind, role: feedback.kind === 'failed' ? 'alert' : 'status' }, feedback.text) : null)
     }
 
     function AuditPage({ audit, auditPage, namespace, onBack }) {
@@ -2470,6 +2552,7 @@ window.__ModuleLoader__.load({
           return next
         }).catch((reason) => {
           if (reason?.name !== 'AbortError') reportError(reason)
+          if (options.propagateError === true && reason?.name !== 'AbortError') throw reason
           return null
         }).finally(() => {
           if (dashboardRequestRef.current === controller) dashboardRequestRef.current = null
@@ -2574,7 +2657,7 @@ window.__ModuleLoader__.load({
         else setSource(null)
       }
       const backLabel = view.back?.name === 'block' ? '短期记忆' : view.back?.name === 'event' ? '长期记忆' : view.back?.name === 'structure' ? '记忆结构' : section === 'short' ? '短期记忆' : '长期记忆'
-      const refresh = () => loadDashboard(namespace, { threadId: conversationId, force: true })
+      const refresh = (options = {}) => loadDashboard(namespace, { threadId: conversationId, force: true, ...options })
       const selectConversation = (nextConversationId) => {
         setConversationId(nextConversationId)
         return loadDashboard(namespace, { threadId: nextConversationId, force: true })
@@ -2593,7 +2676,7 @@ window.__ModuleLoader__.load({
       if (loading && !selected) content = h(Loading)
       else if (!selected) content = h(Empty, { title: '还没有记忆', copy: '完成一些 DSH 对话后，短期记忆和长期记忆会出现在这里。' })
       else if (view.name === 'event') content = h(EventDetail, { event: view.item, project, source, onBack: goBack, backLabel })
-      else if (view.name === 'status') content = h(ProcessingStatus, { overview: selected, blocks: data.blocks, onBack: () => setView({ name: 'root' }), refresh })
+      else if (view.name === 'status') content = h(ProcessingStatus, { overview: selected, blocks: data.blocks, namespace, onBack: () => setView({ name: 'root' }), refresh })
       else if (view.name === 'import') content = h(ImportPage, { namespace, onBack: moreBack, refresh })
       else if (view.name === 'structure') content = h(StructurePage, { events: data.events, eventPage: data.pagination?.events, graph: data.graph, openEvent, namespace, onBack: moreBack })
       else if (view.name === 'system') content = h(SystemPage, { selected, blocks: data.blocks, onBack: moreBack, refresh })

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export type StructuredReasoningEffortMode = 'auto' | 'force-off'
 
 export interface Config {
   database?: string
+  sessionRoot?: string
   namespaceMode?: NamespaceMode
   namespacePrefix?: string
   globalNamespace?: string
@@ -21,6 +22,7 @@ export interface Config {
 
 export interface ResolvedConfig {
   database: string
+  sessionRoot?: string
   namespaceMode: NamespaceMode
   namespacePrefix: string
   globalNamespace: string
@@ -51,6 +53,7 @@ export const StructuredReasoningEffortSettings: z<StructuredReasoningEffortSetti
 
 export const Config: z<Config> = z.object({
   database: z.string().required(),
+  sessionRoot: z.string(),
   namespaceMode: z.union(['project', 'session', 'global'] as const).default('project'),
   namespacePrefix: z.string().default('dsh'),
   globalNamespace: z.string().default('global'),
@@ -62,13 +65,14 @@ export const Config: z<Config> = z.object({
   provider: z.string(),
   model: z.string(),
   maxOutputTokens: z.natural().min(256).default(2_048),
-  structuredTaskTimeoutMs: z.natural().min(1_000).default(45_000),
+  structuredTaskTimeoutMs: z.natural().min(1_000).default(120_000),
   structuredReasoningEffort: z.union(['auto', 'force-off'] as const).default('auto'),
   showShortTermStatus: z.boolean().default(true),
 })
 
 export function resolveConfig(config: Config): ResolvedConfig {
   const database = config.database?.trim() ?? ''
+  const sessionRoot = config.sessionRoot?.trim()
   const namespacePrefix = config.namespacePrefix?.trim() || 'dsh'
   const globalNamespace = config.globalNamespace?.trim() || 'global'
   const provider = config.provider?.trim()
@@ -79,6 +83,7 @@ export function resolveConfig(config: Config): ResolvedConfig {
   }
   return {
     database,
+    ...(sessionRoot ? { sessionRoot } : {}),
     namespaceMode: config.namespaceMode ?? 'project',
     namespacePrefix,
     globalNamespace,
@@ -87,7 +92,7 @@ export function resolveConfig(config: Config): ResolvedConfig {
     ingestSubagents: config.ingestSubagents ?? false,
     ...(provider && model ? { provider, model } : {}),
     maxOutputTokens: Math.max(256, Math.floor(config.maxOutputTokens ?? 2_048)),
-    structuredTaskTimeoutMs: Math.max(1_000, Math.floor(config.structuredTaskTimeoutMs ?? 45_000)),
+    structuredTaskTimeoutMs: Math.max(1_000, Math.floor(config.structuredTaskTimeoutMs ?? 120_000)),
     structuredReasoningEffort: config.structuredReasoningEffort ?? 'auto',
     showShortTermStatus: config.showShortTermStatus ?? true,
   }

--- a/src/dsh-compatibility.ts
+++ b/src/dsh-compatibility.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+const nodeRequire = createRequire(import.meta.url)
+
+const RUNTIME_PACKAGES = [
+  '@deepseek-ai/cordis',
+  '@deepseek-ai/dsh-agent-default-model',
+  '@deepseek-ai/dsh-client-ui-conversation',
+  '@deepseek-ai/dsh-llm',
+  '@deepseek-ai/dsh-session',
+  '@deepseek-ai/dsh-settings',
+  '@deepseek-ai/dsh-system-prompt',
+  '@deepseek-ai/dsh-tools',
+  '@deepseek-ai/schemastery',
+] as const
+
+const SUPPORTED_RUNTIME_FAMILIES = [
+  {
+    cli: '0.1.2-rc.1',
+    versions: {
+      '@deepseek-ai/cordis': '4.0.2',
+      '@deepseek-ai/dsh-agent-default-model': '0.1.2-rc.1',
+      '@deepseek-ai/dsh-client-ui-conversation': '0.1.2-rc.1',
+      '@deepseek-ai/dsh-llm': '0.1.2-rc.1',
+      '@deepseek-ai/dsh-session': '0.1.2-rc.1',
+      '@deepseek-ai/dsh-settings': '0.1.2-rc.1',
+      '@deepseek-ai/dsh-system-prompt': '0.1.2-rc.1',
+      '@deepseek-ai/dsh-tools': '0.1.2-rc.1',
+      '@deepseek-ai/schemastery': '3.18.2',
+    },
+  },
+  {
+    cli: '0.1.5-rc.1',
+    versions: {
+      '@deepseek-ai/cordis': '4.0.2',
+      '@deepseek-ai/dsh-agent-default-model': '0.1.5-rc.2',
+      '@deepseek-ai/dsh-client-ui-conversation': '0.1.5-rc.2',
+      '@deepseek-ai/dsh-llm': '0.1.5-rc.2',
+      '@deepseek-ai/dsh-session': '0.1.5-rc.2',
+      '@deepseek-ai/dsh-settings': '0.1.5-rc.2',
+      '@deepseek-ai/dsh-system-prompt': '0.1.5-rc.2',
+      '@deepseek-ai/dsh-tools': '0.1.5-rc.2',
+      '@deepseek-ai/schemastery': '3.18.2',
+    },
+  },
+] as const
+
+export interface DshRuntimeCompatibility {
+  cliVersion: '0.1.2-rc.1' | '0.1.5-rc.1'
+  packageVersions: Readonly<Record<string, string>>
+}
+
+export type DshRuntimePackageVersions = Readonly<Record<(typeof RUNTIME_PACKAGES)[number], string>>
+
+function installedVersion(packageName: string): string {
+  try {
+    const manifestPath = nodeRequire.resolve(`${packageName}/package.json`)
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: unknown }
+    if (typeof manifest.version === 'string' && manifest.version.length > 0) return manifest.version
+  } catch {}
+  return '<missing>'
+}
+
+export function buildDshReplaceSurfaceOp(version: string, start: number, end: number): any {
+  return version === '0.1.2-rc.1'
+    ? { op: 'replace', start, end }
+    : { op: 'replace', startSeq: start, endSeq: end }
+}
+
+export function dshReplaceSurfaceOp(start: number, end: number): any {
+  return buildDshReplaceSurfaceOp(installedVersion('@deepseek-ai/dsh-session'), start, end)
+}
+
+/**
+ * Fail before registering services when a profile-local peer tree shadows the
+ * DSH installation. A mixed tree otherwise fails later as an empty conversation
+ * surface with unrelated missing-service or method errors.
+ */
+export function classifyDshRuntime(packageVersions: DshRuntimePackageVersions): DshRuntimeCompatibility {
+  const family = SUPPORTED_RUNTIME_FAMILIES.find(({ versions }) => (
+    RUNTIME_PACKAGES.every((name) => packageVersions[name] === versions[name])
+  ))
+  if (family) return { cliVersion: family.cli, packageVersions }
+
+  const found = RUNTIME_PACKAGES.map((name) => `${name}@${packageVersions[name]}`).join(', ')
+  throw new Error(
+    'StrataGate cannot start because this DSH profile resolves an unsupported or mixed core runtime. '
+    + `Resolved: ${found}. Supported tested hosts are @deepseek-ai/dsh@0.1.2-rc.1 `
+    + '(internal DSH packages 0.1.2-rc.1) and @deepseek-ai/dsh@0.1.5-rc.1 '
+    + '(its real dependency tree uses internal DSH packages 0.1.5-rc.2). '
+    + 'Reinstall or update stratagate-dsh through `dsh plugin --profile <name> add <package>` so the host supplies its peers.',
+  )
+}
+
+export function assertCompatibleDshRuntime(): DshRuntimeCompatibility {
+  const packageVersions = Object.fromEntries(RUNTIME_PACKAGES.map((name) => [name, installedVersion(name)])) as DshRuntimePackageVersions
+  return classifyDshRuntime(packageVersions)
+}

--- a/src/dsh-host-resolution.ts
+++ b/src/dsh-host-resolution.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { createRequire, registerHooks } from 'node:module'
+import { dirname, isAbsolute, join, relative } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const HOST_PACKAGES = [
+  '@deepseek-ai/cordis',
+  '@deepseek-ai/dsh-agent-default-model',
+  '@deepseek-ai/dsh-client-ui-conversation',
+  '@deepseek-ai/dsh-llm',
+  '@deepseek-ai/dsh-session',
+  '@deepseek-ai/dsh-session-format',
+  '@deepseek-ai/dsh-session-format-catalog',
+  '@deepseek-ai/dsh-session-format-v0-to-v1',
+  '@deepseek-ai/dsh-settings',
+  '@deepseek-ai/dsh-system-prompt',
+  '@deepseek-ai/dsh-tools',
+  '@deepseek-ai/schemastery',
+] as const
+
+const installedHooks = Symbol.for('stratagate.dsh-host-resolution.v1')
+
+function isWithin(path: string, root: string): boolean {
+  const child = relative(root, path)
+  return child === '' || (!child.startsWith('..') && !isAbsolute(child))
+}
+
+function profileDirectory(start: string): string | undefined {
+  let directory = start
+  for (;;) {
+    const manifestPath = join(directory, 'package.json')
+    if (existsSync(manifestPath)) {
+      try {
+        const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { dsh?: { profile?: unknown } }
+        if (manifest.dsh?.profile && typeof manifest.dsh.profile === 'object') return directory
+      } catch {}
+    }
+    const parent = dirname(directory)
+    if (parent === directory) return undefined
+    directory = parent
+  }
+}
+
+function hostPackage(specifier: string): boolean {
+  return HOST_PACKAGES.some((name) => specifier === name || specifier.startsWith(`${name}/`))
+}
+
+/**
+ * Force only StrataGate's DSH imports through the installation-owned fallback
+ * created by DSH. The hook neither deletes nor rewrites the profile's package
+ * tree, and imports belonging to the host or other plugins are untouched.
+ */
+export function installDshHostResolution(moduleUrl: string): boolean {
+  const packageDirectory = dirname(dirname(fileURLToPath(moduleUrl)))
+  const profile = profileDirectory(packageDirectory)
+  if (!profile) return false
+
+  const globalState = globalThis as typeof globalThis & { [installedHooks]?: Set<string> }
+  const installed = globalState[installedHooks] ??= new Set<string>()
+  const key = `${profile}\u0000${packageDirectory}`
+  if (installed.has(key)) return true
+
+  const fallbackModules = join(dirname(profile), 'node_modules')
+  const hostRequire = createRequire(join(fallbackModules, '.stratagate-host-resolution.cjs'))
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      const parent = context.parentURL?.startsWith('file:') ? fileURLToPath(context.parentURL) : undefined
+      if (!hostPackage(specifier) || !parent || !isWithin(parent, packageDirectory)) {
+        return nextResolve(specifier, context)
+      }
+      try {
+        return { url: pathToFileURL(hostRequire.resolve(specifier)).href, shortCircuit: true }
+      } catch (cause) {
+        if (specifier === '@deepseek-ai/dsh-session-format-v0-to-v1'
+          || specifier === '@deepseek-ai/dsh-session-format-catalog') {
+          return nextResolve(specifier, context)
+        }
+        throw new Error(
+          `StrataGate cannot resolve host-provided DSH package ${JSON.stringify(specifier)} from ${fallbackModules}. `
+          + 'Start StrataGate through the DSH profile launcher so the host can prepare its module fallback.',
+          { cause },
+        )
+      }
+    },
+  })
+  installed.add(key)
+  return true
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { DshModelBridge } from './llm.js'
 import { StrataGateRuntime } from './runtime.js'
 import { registerMemoryTools } from './tools.js'
 import { registerAdminRoutes } from './web.js'
+import { assertCompatibleDshRuntime } from './dsh-compatibility.js'
+import { migrateLegacyCitationSessions } from './legacy-session.js'
 import type {} from '@deepseek-ai/dsh-agent-default-model'
 import type {} from '@deepseek-ai/dsh-agent'
 import type {} from '@deepseek-ai/dsh-llm'
@@ -61,7 +63,16 @@ function feedbackWebOrigin(ctx: Context): string | undefined {
 }
 
 export async function apply(ctx: Context, config: StrataGateConfig): Promise<() => Promise<void>> {
+  const compatibility = assertCompatibleDshRuntime()
   const resolved = resolveConfig(config)
+  const legacyMigration = await migrateLegacyCitationSessions(resolved.sessionRoot)
+  if (legacyMigration.failures.length > 0) {
+    const detail = legacyMigration.failures.map(({ path, error }) => `${path}: ${error}`).join('; ')
+    throw new Error(`StrataGate could not safely migrate legacy citation events: ${detail}`)
+  }
+  if (legacyMigration.migrated > 0) {
+    ctx.logger.info(`stratagate-memory prepared ${legacyMigration.migrated} legacy Session generation(s) for DSH 0.1.5`)
+  }
   await mkdir(dirname(resolved.database), { recursive: true })
   const models = new DshModelBridge(ctx, resolved)
   const runtime = new StrataGateRuntime(resolved, models, (error) => {
@@ -127,7 +138,7 @@ export async function apply(ctx: Context, config: StrataGateConfig): Promise<() 
   const disposeAdminRoutes = registerAdminRoutes(ctx, runtime)
   ctx.on('session/event', (session, event) => runtime.acceptEvent(session, event))
 
-  ctx.logger.info(`stratagate-memory ready (${resolved.namespaceMode} namespaces, ${resolved.database})`)
+  ctx.logger.info(`stratagate-memory ready (DSH ${compatibility.cliVersion}, ${resolved.namespaceMode} namespaces, ${resolved.database})`)
   return async () => {
     disposeAdminRoutes?.()
     await runtime.close()

--- a/src/legacy-session.ts
+++ b/src/legacy-session.ts
@@ -1,0 +1,381 @@
+import * as zlib from 'node:zlib'
+import { constants as fsConstants } from 'node:fs'
+import {
+  copyFile,
+  link,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  unlink,
+  writeFile,
+} from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+import { createHash, randomUUID } from 'node:crypto'
+import { encodeSeqRanges } from '@deepseek-ai/dsh-session'
+import type {
+  SessionFormatEvent,
+  SessionFormatJsonObject,
+  SessionFormatMigrationContext,
+} from '@deepseek-ai/dsh-session-format'
+
+const LEGACY_EVENT_TYPE = 'stratagate/memory-citations'
+const COMPAT_EVENT_TYPE = 'feedback/record'
+const ZSTD_MAGIC = 0xfd2fb528
+const V0_PLAIN = 'session.jsonl'
+const V0_ZSTD = 'session.jsonl.zstd'
+const V1_PLAIN = 'session.v1.jsonl'
+const V1_ZSTD = 'session.v1.jsonl.zstd'
+const RECEIPT_FILENAME = 'stratagate-legacy-citations-v1.json'
+
+interface MigrationModules {
+  releasedV0SessionFormatCodec: {
+    createDecoder(header: unknown, recovery: 'strict'): {
+      header: Record<string, unknown>
+      headerInheritedEventCount?: number
+      decodeRow(row: unknown, context: SessionFormatMigrationContext): void
+      finish(context: SessionFormatMigrationContext): number
+    }
+  }
+  releasedV1SessionFormatCodec: {
+    decodeHeader(header: unknown): unknown
+  }
+  sessionFormatV0ToV1: {
+    migrateHeader(header: any): any
+    createStage(input: any): {
+      transformEvent(event: SessionFormatEvent, context: SessionFormatMigrationContext): void
+      transformRun(run: any, context: SessionFormatMigrationContext): void
+      finish(context: SessionFormatMigrationContext): number
+    }
+    validateTargetHeader(header: unknown): void
+  }
+  sessionFormatCatalog: {
+    createRestore(header: unknown, options: { recovery: 'strict'; validation: 'transformed' }): {
+      decodeRow(row: unknown): void
+      finish(): { events: readonly SessionFormatEvent[] }
+    }
+  }
+}
+
+export interface LegacySessionMigrationResult {
+  scanned: number
+  migrated: number
+  skipped: number
+  failures: ReadonlyArray<{ path: string; error: string }>
+}
+
+interface PreparedGeneration {
+  bytes: Buffer
+  citationSeqs: number[]
+  currentEvents: readonly SessionFormatEvent[]
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/** Locate complete concatenated Zstandard frames without decoding their blocks. */
+export function scanZstdFrames(buffer: Buffer): ReadonlyArray<{ start: number; end: number }> {
+  const frames: Array<{ start: number; end: number }> = []
+  let offset = 0
+  while (offset < buffer.length) {
+    const start = offset
+    if (buffer.length - offset < 5) throw new Error(`incomplete Zstandard frame at byte ${start}`)
+    if (buffer.readUInt32LE(offset) !== ZSTD_MAGIC) throw new Error(`invalid Zstandard frame magic at byte ${offset}`)
+    offset += 4
+    const descriptor = buffer.readUInt8(offset)
+    offset += 1
+    if ((descriptor & 24) !== 0) throw new Error(`reserved Zstandard frame-header bit at byte ${offset - 1}`)
+    const contentSizeFlag = descriptor >>> 6
+    const singleSegment = (descriptor & 32) !== 0
+    const checksum = (descriptor & 4) !== 0
+    const dictionaryFlag = descriptor & 3
+    const dictionaryBytes = dictionaryFlag === 3 ? 4 : dictionaryFlag
+    const contentSizeBytes = contentSizeFlag === 0 ? (singleSegment ? 1 : 0) : 1 << contentSizeFlag
+    const remainingHeaderBytes = (singleSegment ? 0 : 1) + dictionaryBytes + contentSizeBytes
+    if (buffer.length - offset < remainingHeaderBytes) throw new Error(`incomplete Zstandard frame header at byte ${start}`)
+    offset += remainingHeaderBytes
+    for (;;) {
+      if (buffer.length - offset < 3) throw new Error(`incomplete Zstandard block header at byte ${start}`)
+      const blockHeader = buffer.readUIntLE(offset, 3)
+      offset += 3
+      const lastBlock = (blockHeader & 1) !== 0
+      const blockType = (blockHeader >>> 1) & 3
+      const blockSize = blockHeader >>> 3
+      if (blockType === 3) throw new Error(`reserved Zstandard block type at byte ${offset - 3}`)
+      const payloadBytes = blockType === 1 ? 1 : blockSize
+      if (buffer.length - offset < payloadBytes) throw new Error(`incomplete Zstandard block at byte ${start}`)
+      offset += payloadBytes
+      if (lastBlock) break
+    }
+    if (checksum) {
+      if (buffer.length - offset < 4) throw new Error(`incomplete Zstandard checksum at byte ${start}`)
+      offset += 4
+    }
+    frames.push({ start, end: offset })
+  }
+  return frames
+}
+
+function decodeGeneration(bytes: Buffer, compression: 'none' | 'zstd'): Buffer {
+  if (compression === 'none') return bytes
+  return Buffer.concat(scanZstdFrames(bytes).map(({ start, end }) => (
+    zlib.zstdDecompressSync(bytes.subarray(start, end))
+  )))
+}
+
+function encodeGeneration(header: SessionFormatJsonObject, rows: readonly SessionFormatJsonObject[], compression: 'none' | 'zstd'): Buffer {
+  const headerLine = Buffer.from(`${JSON.stringify(header)}\n`)
+  const body = Buffer.from(rows.length === 0 ? '' : `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`)
+  if (compression === 'none') return Buffer.concat([headerLine, body])
+  const options = { params: { [zlib.constants.ZSTD_c_checksumFlag]: 1 } }
+  return Buffer.concat([
+    zlib.zstdCompressSync(headerLine, options),
+    ...(body.length === 0 ? [] : [zlib.zstdCompressSync(body, options)]),
+  ])
+}
+
+function physicalV1Event(event: SessionFormatEvent): SessionFormatJsonObject {
+  const output = { ...event } as Record<string, any>
+  if (Array.isArray(output.sourceEventSeqs)) output.sourceEventSeqs = encodeSeqRanges(output.sourceEventSeqs)
+  return output
+}
+
+function compatibilityEvent(event: SessionFormatEvent): SessionFormatEvent {
+  if (event.ignorable !== true) {
+    throw new Error(`${LEGACY_EVENT_TYPE} at seq ${event.seq} is not marked ignorable; refusing an unsafe conversion`)
+  }
+  if ('surfaceOp' in event || 'sourceEventSeqs' in event) {
+    throw new Error(`${LEGACY_EVENT_TYPE} at seq ${event.seq} unexpectedly participates in the conversation surface`)
+  }
+  return {
+    ...event,
+    type: COMPAT_EVENT_TYPE,
+    data: { text: 'StrataGate legacy citation metadata omitted during Session format migration.' },
+  }
+}
+
+function parseJsonLines(plain: Buffer): unknown[] {
+  if (plain.length === 0 || plain.at(-1) !== 10) throw new Error('Session generation does not end at a complete JSONL record')
+  const text = plain.toString('utf8')
+  const lines = text.slice(0, -1).split('\n')
+  if (lines.length === 0 || lines[0] === '') throw new Error('Session generation has no header')
+  return lines.map((line, index) => {
+    try {
+      return JSON.parse(line)
+    } catch (error) {
+      throw new Error(`invalid Session JSONL record ${index}`, { cause: error })
+    }
+  })
+}
+
+export function prepareLegacyCitationGeneration(
+  sourceBytes: Buffer,
+  compression: 'none' | 'zstd',
+  modules: MigrationModules,
+): PreparedGeneration | undefined {
+  const values = parseJsonLines(decodeGeneration(sourceBytes, compression))
+  const [headerValue, ...rowValues] = values
+  if (!isRecord(headerValue) || headerValue.version !== 0) return undefined
+  if (!rowValues.some((row) => isRecord(row) && row.type === LEGACY_EVENT_TYPE)) return undefined
+
+  const decoder = modules.releasedV0SessionFormatCodec.createDecoder(headerValue, 'strict')
+  const targetHeader = modules.sessionFormatV0ToV1.migrateHeader(decoder.header)
+  modules.sessionFormatV0ToV1.validateTargetHeader(targetHeader)
+  const stage = modules.sessionFormatV0ToV1.createStage({
+    sourceHeader: decoder.header,
+    targetHeader,
+    sourceInheritedEventCount: decoder.headerInheritedEventCount,
+    sourceKind: 'decoded',
+  })
+  const outputRows: SessionFormatJsonObject[] = []
+  const citationSeqs: number[] = []
+  let physicalRow: unknown
+  const stageContext: SessionFormatMigrationContext = {
+    emitEvent(event) { outputRows.push(physicalV1Event(event)) },
+    emitRun() {
+      if (!isRecord(physicalRow)) throw new Error('DSH emitted a packed run without its physical source row')
+      outputRows.push(physicalRow)
+    },
+  }
+  const decodeContext: SessionFormatMigrationContext = {
+    emitEvent(event) {
+      if (event.type === LEGACY_EVENT_TYPE) {
+        citationSeqs.push(event.seq)
+        stage.transformEvent(compatibilityEvent(event), stageContext)
+      } else {
+        stage.transformEvent(event, stageContext)
+      }
+    },
+    emitRun(run) { stage.transformRun(run, stageContext) },
+  }
+  for (const row of rowValues) {
+    physicalRow = row
+    decoder.decodeRow(row, decodeContext)
+  }
+  const decodedCut = decoder.finish(decodeContext)
+  const migratedCut = stage.finish(stageContext)
+  if (decodedCut !== migratedCut) throw new Error('StrataGate compatibility migration changed the inherited Session cut')
+
+  const physicalHeader = { ...headerValue, version: 1 } as SessionFormatJsonObject
+  modules.releasedV1SessionFormatCodec.decodeHeader(physicalHeader)
+  const restore = modules.sessionFormatCatalog.createRestore(physicalHeader, {
+    recovery: 'strict',
+    validation: 'transformed',
+  })
+  for (const row of outputRows) restore.decodeRow(row)
+  const current = restore.finish()
+  return {
+    bytes: encodeGeneration(physicalHeader, outputRows, compression),
+    citationSeqs,
+    currentEvents: current.events,
+  }
+}
+
+async function loadMigrationModules(): Promise<MigrationModules | undefined> {
+  try {
+    const [edge, catalog] = await Promise.all([
+      import('@deepseek-ai/dsh-session-format-v0-to-v1'),
+      import('@deepseek-ai/dsh-session-format-catalog'),
+    ])
+    return {
+      releasedV0SessionFormatCodec: edge.releasedV0SessionFormatCodec,
+      releasedV1SessionFormatCodec: edge.releasedV1SessionFormatCodec,
+      sessionFormatV0ToV1: edge.sessionFormatV0ToV1,
+      sessionFormatCatalog: catalog.sessionFormatCatalog,
+    } as MigrationModules
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ERR_MODULE_NOT_FOUND') return undefined
+    throw error
+  }
+}
+
+async function sessionDirectories(root: string): Promise<string[]> {
+  let projects
+  try {
+    projects = await readdir(root, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+  const output: string[] = []
+  for (const project of projects) {
+    if (!project.isDirectory() || project.isSymbolicLink()) continue
+    const projectPath = join(root, project.name)
+    for (const session of await readdir(projectPath, { withFileTypes: true })) {
+      if (session.isDirectory() && !session.isSymbolicLink()) output.push(join(projectPath, session.name))
+    }
+  }
+  return output
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    return (await lstat(path)).isFile()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+    throw error
+  }
+}
+
+async function publishExclusive(path: string, bytes: Buffer): Promise<boolean> {
+  await mkdir(dirname(path), { recursive: true })
+  const temporary = join(dirname(path), `.${basename(path)}.stratagate-${randomUUID()}.tmp`)
+  const handle = await open(temporary, 'wx', 0o600)
+  try {
+    await handle.writeFile(bytes)
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  try {
+    await link(temporary, path)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false
+    // Some filesystems do not provide hard links. COPYFILE_EXCL still preserves
+    // the no-overwrite guarantee; the fully synced temporary remains the source.
+    if ((error as NodeJS.ErrnoException).code === 'EPERM' || (error as NodeJS.ErrnoException).code === 'ENOTSUP') {
+      try {
+        await copyFile(temporary, path, fsConstants.COPYFILE_EXCL)
+        return true
+      } catch (copyError) {
+        if ((copyError as NodeJS.ErrnoException).code === 'EEXIST') return false
+        throw copyError
+      }
+    }
+    throw error
+  } finally {
+    await unlink(temporary).catch(() => {})
+  }
+}
+
+async function writeReceipt(directory: string, sourcePath: string, targetPath: string, source: Buffer, target: Buffer, citationSeqs: readonly number[]): Promise<void> {
+  const receipt = {
+    schema: 'stratagate-legacy-citations-migration/v1',
+    source: basename(sourcePath),
+    sourceSha256: sha256(source),
+    target: basename(targetPath),
+    targetSha256: sha256(target),
+    convertedEventType: LEGACY_EVENT_TYPE,
+    replacementEventType: COMPAT_EVENT_TYPE,
+    citationSeqs,
+    recovery: `Delete ${basename(targetPath)} only while DSH is stopped to make the unchanged ${basename(sourcePath)} generation authoritative again.`,
+  }
+  await writeFile(join(directory, RECEIPT_FILENAME), `${JSON.stringify(receipt, null, 2)}\n`, { flag: 'wx', mode: 0o600 }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+  })
+}
+
+/**
+ * Publish a validated v1 bridge for v0 sessions containing StrataGate's retired
+ * citation event. The immutable v0 generation is never changed or removed.
+ */
+export async function migrateLegacyCitationSessions(sessionRoot: string | undefined): Promise<LegacySessionMigrationResult> {
+  const result: LegacySessionMigrationResult = { scanned: 0, migrated: 0, skipped: 0, failures: [] }
+  if (!sessionRoot) return result
+  const modules = await loadMigrationModules()
+  // DSH 0.1.2 has no released-format migration catalog and needs no bridge.
+  if (!modules) return result
+
+  for (const directory of await sessionDirectories(sessionRoot)) {
+    const candidates = [
+      { source: join(directory, V0_ZSTD), target: join(directory, V1_ZSTD), compression: 'zstd' as const },
+      { source: join(directory, V0_PLAIN), target: join(directory, V1_PLAIN), compression: 'none' as const },
+    ]
+    for (const candidate of candidates) {
+      if (!(await exists(candidate.source))) continue
+      result.scanned += 1
+      if (await exists(candidate.target)) {
+        result.skipped += 1
+        continue
+      }
+      try {
+        const source = await readFile(candidate.source)
+        const prepared = prepareLegacyCitationGeneration(source, candidate.compression, modules)
+        if (!prepared) {
+          result.skipped += 1
+          continue
+        }
+        if (await publishExclusive(candidate.target, prepared.bytes)) {
+          await writeReceipt(directory, candidate.source, candidate.target, source, prepared.bytes, prepared.citationSeqs)
+          result.migrated += 1
+        } else {
+          result.skipped += 1
+        }
+      } catch (error) {
+        ;(result.failures as Array<{ path: string; error: string }>).push({ path: candidate.source, error: errorText(error) })
+      }
+    }
+  }
+  return result
+}

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -71,7 +71,7 @@ function extractorPayload(context: ExtractionContext): Record<string, unknown> {
 
 const JSON_RESPONSE_ATTEMPTS = 2
 const JSON_RETRY_INSTRUCTION = 'Your previous response did not make one valid call to the requested tool. Do not spend output on analysis or reasoning. Immediately call that tool exactly once with complete arguments. Do not return an answer as text or markdown.'
-const DEFAULT_STRUCTURED_TIMEOUT_MS = 45_000
+const DEFAULT_STRUCTURED_TIMEOUT_MS = 120_000
 const STRUCTURED_FIELDS = {
   summarizer: ['l0Title', 'l0Tags', 'l1Summary', 'l2Keypoints', 'shouldExtract'],
   extractor: ['shouldExtract', 'reason', 'events'],

--- a/src/repair-profile.ts
+++ b/src/repair-profile.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { existsSync, lstatSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { basename, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PROFILE_PACKAGES = [
+  '@deepseek-ai/cordis',
+  '@deepseek-ai/cosmokit',
+  '@deepseek-ai/dsh-agent',
+  '@deepseek-ai/dsh-agent-default-model',
+  '@deepseek-ai/dsh-brand',
+  '@deepseek-ai/dsh-client-ui-conversation',
+  '@deepseek-ai/dsh-code-runtime',
+  '@deepseek-ai/dsh-invariants',
+  '@deepseek-ai/dsh-llm',
+  '@deepseek-ai/dsh-scope',
+  '@deepseek-ai/dsh-session',
+  '@deepseek-ai/dsh-session-format',
+  '@deepseek-ai/dsh-session-format-catalog',
+  '@deepseek-ai/dsh-session-format-v0-to-v1',
+  '@deepseek-ai/dsh-session-projection',
+  '@deepseek-ai/dsh-settings',
+  '@deepseek-ai/dsh-system-prompt',
+  '@deepseek-ai/dsh-timeout',
+  '@deepseek-ai/dsh-tools',
+  '@deepseek-ai/dsh-typert-protocol',
+  '@deepseek-ai/dsh-user-approval',
+  '@deepseek-ai/dsh-util-crypto',
+  '@deepseek-ai/dsh-util-values',
+  '@deepseek-ai/schemastery',
+] as const
+
+function profileDirectory(start: string): string {
+  let directory = start
+  for (;;) {
+    const manifestPath = join(directory, 'package.json')
+    if (existsSync(manifestPath)) {
+      try {
+        const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { dsh?: { profile?: unknown } }
+        if (manifest.dsh?.profile && typeof manifest.dsh.profile === 'object') return directory
+      } catch {}
+    }
+    const parent = dirname(directory)
+    if (parent === directory) {
+      throw new Error('stratagate-dsh-repair must run inside an installed DSH profile')
+    }
+    directory = parent
+  }
+}
+
+function main(): void {
+  const profile = profileDirectory(dirname(fileURLToPath(import.meta.url)))
+  const modules = join(profile, 'node_modules')
+  const candidates = PROFILE_PACKAGES
+    .map((name) => ({ name, source: join(modules, ...name.split('/')) }))
+    .filter(({ source }) => {
+      try {
+        lstatSync(source)
+        return true
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+        throw error
+      }
+    })
+  if (candidates.length === 0) {
+    process.stdout.write('StrataGate profile runtime is already isolated; no DSH peer residue found.\n')
+    return
+  }
+
+  const backup = join(profile, '.stratagate-runtime-backups', `${Date.now()}-${process.pid}-${randomUUID()}`)
+  const moved: Array<{ name: string; source: string; target: string }> = []
+  try {
+    for (const candidate of candidates) {
+      const target = join(backup, 'node_modules', ...candidate.name.split('/'))
+      mkdirSync(dirname(target), { recursive: true })
+      renameSync(candidate.source, target)
+      moved.push({ ...candidate, target })
+    }
+    const receipt = {
+      schema: 'stratagate-dsh-profile-runtime-repair/v1',
+      profile,
+      createdAt: new Date().toISOString(),
+      packages: moved.map(({ name, source, target }) => ({ name, source, target })),
+      recovery: `While DSH is stopped, move the listed targets back to their source paths if this repair must be reversed.`,
+    }
+    writeFileSync(join(backup, 'receipt.json'), `${JSON.stringify(receipt, null, 2)}\n`, { flag: 'wx', mode: 0o600 })
+  } catch (error) {
+    for (const item of moved.reverse()) {
+      if (existsSync(item.target) && !existsSync(item.source)) renameSync(item.target, item.source)
+    }
+    throw error
+  }
+  process.stdout.write(`Quarantined ${moved.length} stale DSH profile package(s) to ${backup}\n`)
+}
+
+try {
+  main()
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`)
+  process.exitCode = 1
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -33,6 +33,7 @@ import {
 import { SqliteStorage } from '@diqier/stratagate/sqlite'
 import type { ResolvedConfig } from './config.js'
 import { TurnFolder, type FoldedTurn } from './fold.js'
+import { dshReplaceSurfaceOp } from './dsh-compatibility.js'
 import { DshModelBridge } from './llm.js'
 import { DshMetadataStore } from './metadata.js'
 
@@ -165,8 +166,11 @@ export class StrataGateRuntime {
   private readonly migrationTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly derivationTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private readonly derivationRuns = new Map<string, Promise<void>>()
+  private readonly knownSessions = new Map<string, WeakRef<Session>>()
+  private readonly pendingSurfaceSync = new Map<string, { namespace: string; blockId: string }>()
   private readonly adminSnapshotCache = new Map<string, AdminSnapshotEntry>()
   private readonly externalImportRuns = new Map<string, Promise<void>>()
+  private readonly adminJobRetryRuns = new Map<string, Promise<unknown>>()
   private readonly feedbackDrafts = new Map<string, FeedbackDraft>()
   private readonly pendingFeedbackSuggestionSessions = new Set<string>()
   private readonly pendingTurns = new Map<string, FoldedTurn[]>()
@@ -259,7 +263,10 @@ export class StrataGateRuntime {
     this.drainTimers.set(key, timer)
   }
 
-  /** Restore failed and unvisited turns ahead of turns that arrived during the drain. */
+  /**
+   * Persist one detached batch. On failure, the failed and unvisited turns are
+   * restored ahead of turns that arrived meanwhile, preserving original order.
+   */
   private async drain(session: Session): Promise<void> {
     const key = String(session.id)
     const turns = this.pendingTurns.get(key)
@@ -641,7 +648,7 @@ export class StrataGateRuntime {
       content: [{ type: 'text', text: renderBlockSurfaceMessage(context) }],
       source: { kind: 'plugin', plugin: COMPACTION_SOURCE_PLUGIN },
     }), {
-      surfaceOp: { op: 'replace', start, end },
+      surfaceOp: dshReplaceSurfaceOp(start, end),
       sourceEventSeqs,
     })
   }
@@ -659,12 +666,41 @@ export class StrataGateRuntime {
         content: [{ type: 'text', text }],
         source: { kind: 'plugin', plugin: COMPACTION_SOURCE_PLUGIN },
       }), {
-        surfaceOp: { op: 'replace', start: node.seq, end: node.seq },
+        surfaceOp: dshReplaceSurfaceOp(node.seq, node.seq),
         sourceEventSeqs: [node.seq],
       })
       changed = true
     }
     return changed
+  }
+
+  /** Finish native-surface replacement when an admin retry ran without the target session loaded. */
+  private async syncPendingRetrySurface(session: Session, memory: StrataGate): Promise<void> {
+    const namespace = this.namespaceFor(session)
+    const threadId = String(session.id)
+    const pending = [...this.pendingSurfaceSync.entries()]
+      .filter(([, item]) => item.namespace === namespace)
+    if (pending.length === 0) return
+    const contexts = new Map(memory.getBlockContext(threadId).map((context) => [context.id, context]))
+    const existing = currentBlockSurfaceMessages(session)
+    let changed = false
+    for (const [key, { blockId }] of pending) {
+      if (existing.has(blockId)) {
+        this.pendingSurfaceSync.delete(key)
+        continue
+      }
+      const block = memory.listBlocks().find((candidate) => candidate.id === blockId && candidate.threadId === threadId)
+      const context = contexts.get(blockId)
+      if (!block || block.processingStatus !== 'ready' || !context) continue
+      try {
+        this.replaceSealedSurface(session, block, context, dshTurnAtBlockEnd(session, block))
+        this.pendingSurfaceSync.delete(key)
+        changed = true
+      } catch (error) {
+        this.onIngestError(error)
+      }
+    }
+    if (changed) await this.flushNativeSession(session)
   }
 
   // Keep the ingestion error for callers that explicitly require a flushed run.
@@ -1238,6 +1274,79 @@ export class StrataGateRuntime {
     return update
   }
 
+  async adminRetryJob(namespace: string, kind: 'block-summary' | 'event-extraction' | 'graph-projection', id: string): Promise<unknown> {
+    const key = namespace.trim()
+    const jobId = id.trim()
+    if (!key) throw new TypeError('StrataGate admin namespace must not be empty')
+    if (!jobId) throw new TypeError('StrataGate job id must not be empty')
+    const retryKey = `${key}\u0000${kind}\u0000${jobId}`
+    const existing = this.adminJobRetryRuns.get(retryKey)
+    if (existing) return existing
+    const update = this.settingsTail.catch(() => {}).then(async () => {
+      await this.flush()
+      const { memory, owned } = await this.openAdminMemory(key, { derivation: true })
+      try {
+        await this.refreshExternalImportMemory(key, memory)
+        const graphJob = kind === 'graph-projection'
+          ? memory.listGraphProjectionJobs().find((candidate) => candidate.id === jobId)
+          : undefined
+        const blockId = kind === 'graph-projection'
+          ? graphJob?.sourceEventIds.flatMap((eventId) => memory.listEvents().find(({ id: eventCandidateId }) => eventCandidateId === eventId)?.sourceBlockId ?? [])[0]
+          : jobId
+        const block = blockId ? memory.listBlocks().find((candidate) => candidate.id === blockId) : undefined
+        if (kind !== 'graph-projection' && !block) throw new Error(`Unknown block: ${jobId}`)
+        if (kind === 'graph-projection' && !graphJob) throw new Error(`Unknown graph projection: ${jobId}`)
+        const threadId = block?.threadId ?? `admin-job-retry:${kind}:${jobId}`
+        const session = block?.threadId ? this.knownSessions.get(block.threadId)?.deref() : undefined
+        const retry = async (): Promise<unknown> => {
+          if (kind === 'block-summary') return memory.retryBlockSummary(jobId)
+          if (kind === 'event-extraction') return memory.retryEventExtraction(jobId)
+          return memory.retryGraphProjection(jobId)
+        }
+        const result = session && this.namespaceFor(session) === key
+          ? await this.models.run(session, retry)
+          : await this.models.runDetached(threadId, retry)
+        await this.persistSuccessfulResponses(memory)
+        const currentBlock = blockId ? memory.listBlocks().find(({ id: candidateId }) => candidateId === blockId) : undefined
+        if (kind !== 'graph-projection' && currentBlock?.processingStatus === 'ready' && currentBlock.threadId) {
+          this.pendingSurfaceSync.set(`${key}\u0000${currentBlock.id}`, { namespace: key, blockId: currentBlock.id })
+          if (session && this.namespaceFor(session) === key) await this.syncPendingRetrySurface(session, memory)
+        }
+        const job = kind === 'block-summary'
+          ? memory.listSummaryJobs().find(({ blockId: candidateId }) => candidateId === jobId)
+          : kind === 'event-extraction'
+            ? memory.listExtractionJobs().find(({ blockId: candidateId }) => candidateId === jobId)
+            : memory.listGraphProjectionJobs().find(({ id: candidateId }) => candidateId === jobId)
+        const succeeded = kind === 'graph-projection' ? job?.status === 'completed' : job?.status === 'succeeded' || job?.status === 'skipped'
+        if (!succeeded) throw new Error(job?.lastError || `${kind} retry did not complete`)
+        return {
+          kind,
+          jobId,
+          blockId,
+          status: job?.status,
+          job: job ?? null,
+          ...(kind === 'block-summary' ? { summaryJob: job ?? null } : {}),
+          result,
+          processingStatus: currentBlock?.processingStatus ?? null,
+          ready: currentBlock?.processingStatus === 'ready',
+          surfaceUpdated: !blockId || !this.pendingSurfaceSync.has(`${key}\u0000${blockId}`),
+        }
+      } finally {
+        if (owned) await memory.close()
+      }
+    })
+    this.settingsTail = update.then(() => {}, () => {})
+    const tracked = update.finally(() => {
+      if (this.adminJobRetryRuns.get(retryKey) === tracked) this.adminJobRetryRuns.delete(retryKey)
+    })
+    this.adminJobRetryRuns.set(retryKey, tracked)
+    return tracked
+  }
+
+  async adminRetryBlockSummary(namespace: string, id: string): Promise<unknown> {
+    return this.adminRetryJob(namespace, 'block-summary', id)
+  }
+
   private async applyBlockDecayLambda(value: number): Promise<void> {
     await this.flush()
     this.blockDecayLambda = value
@@ -1304,8 +1413,9 @@ export class StrataGateRuntime {
     }
   }
 
-  private space(session: Session): Promise<StrataGate> {
+  private async space(session: Session): Promise<StrataGate> {
     const namespace = this.namespaceFor(session)
+    this.knownSessions.set(String(session.id), new WeakRef(session))
     this.rememberWorkspace(namespace, session.header.cwd)
     let opening = this.spaces.get(namespace)
     if (!opening) {
@@ -1340,7 +1450,9 @@ export class StrataGateRuntime {
         if (this.spaces.get(namespace) === opening) this.spaces.delete(namespace)
       })
     }
-    return opening
+    const memory = await opening
+    await this.syncPendingRetrySurface(session, memory)
+    return memory
   }
 
   async searchGraph(session: Session, query: string, limit = 8): Promise<unknown> {
@@ -1468,7 +1580,10 @@ export class StrataGateRuntime {
     if ([...this.failedCoreJobs(memory)].some((failure) => !before.has(failure))) this.notePluginError(session)
   }
 
-  private async openAdminMemory(namespace: string): Promise<{ memory: StrataGate; owned: boolean }> {
+  private async openAdminMemory(
+    namespace: string,
+    options: { derivation?: boolean } = {},
+  ): Promise<{ memory: StrataGate; owned: boolean }> {
     const active = this.spaces.get(namespace)
     if (active) return { memory: await active, owned: false }
     if (this.config.database === ':memory:' || !existsSync(this.config.database)) {
@@ -1480,6 +1595,10 @@ export class StrataGateRuntime {
         namespace,
         blockTurnSize: this.blockTurnSize,
         blockDecayLambda: this.blockDecayLambda,
+        ...(options.derivation ? {
+          summarizer: this.models.summarizer,
+          extractor: this.models.extractor,
+        } : {}),
         graphProjector: this.models.graphProjector,
         disableElementProjection: true,
       }),

--- a/src/web.ts
+++ b/src/web.ts
@@ -19,7 +19,7 @@ import {
 import type { AdminSnapshotEntry, FeedbackDraftInput, StrataGateRuntime } from './runtime.js'
 import { clusterKnowledgeGraph } from './graph-clustering.js'
 
-const STRATAGATE_DSH_VERSION = '0.2.52'
+const STRATAGATE_DSH_VERSION = '0.2.64'
 const LEGACY_THREAD_ID = '__legacy__'
 const nodeRequire = createRequire(import.meta.url)
 
@@ -227,32 +227,82 @@ async function overview(runtime: StrataGateRuntime, cachedEntries?: readonly Adm
   const rows = []
   for (const { namespace, snapshot } of entries) {
     if (!snapshot) continue
-    const failedJobs = snapshot.extractionJobs.filter(({ status }) => status === 'failed').length
+    const failedJobs = snapshot.summaryJobs.filter(({ status }) => status === 'failed').length
+      + snapshot.extractionJobs.filter(({ status }) => status === 'failed').length
       + snapshot.graphProjectionJobs.filter(({ status }) => status === 'failed').length
     const processingJobs = snapshot.summaryJobs.filter(({ status, nextRetryAt }) => status === 'pending' || status === 'running' || (status === 'failed' && nextRetryAt !== null)).length
       + snapshot.extractionJobs.filter(({ status, nextRetryAt }) => status === 'running' || (status === 'failed' && nextRetryAt !== null)).length
       + snapshot.graphProjectionJobs.filter(({ status }) => status === 'pending' || status === 'running').length
     const failedJobDetails = [
+      ...snapshot.summaryJobs
+        .filter(({ status }) => status === 'failed')
+        .map((job) => {
+          const block = snapshot.blocks.find(({ id }) => id === job.blockId)
+          return {
+            id: job.blockId,
+            kind: 'block-summary',
+            attempts: job.attempts,
+            nextRetryAt: job.nextRetryAt,
+            lastError: job.lastError?.slice(0, 500) ?? null,
+            lastErrorFull: job.lastError,
+            updatedAt: job.updatedAt,
+            threadId: block?.threadId ?? null,
+            blockIds: [job.blockId],
+            threadIds: block?.threadId ? [block.threadId] : [],
+            blockDetails: block ? [{
+              id: block.id, sequence: block.sequence, title: block.l0Title ?? null,
+              threadId: block.threadId ?? null, turnRange: [block.startTurn, block.endTurn],
+            }] : [],
+            sequence: block?.sequence ?? null,
+            turnRange: block ? [block.startTurn, block.endTurn] : null,
+          }
+        }),
       ...snapshot.extractionJobs
         .filter(({ status }) => status === 'failed')
-        .map((job) => ({
-          id: job.blockId,
-          kind: 'event-extraction',
-          attempts: job.attempts,
-          lastError: job.lastError?.slice(0, 500) ?? null,
-          lastErrorFull: job.lastError,
-          updatedAt: job.updatedAt,
-        })),
+        .map((job) => {
+          const block = snapshot.blocks.find(({ id }) => id === job.blockId)
+          return {
+            id: job.blockId,
+            kind: 'event-extraction',
+            attempts: job.attempts,
+            nextRetryAt: job.nextRetryAt,
+            lastError: job.lastError?.slice(0, 500) ?? null,
+            lastErrorFull: job.lastError,
+            updatedAt: job.updatedAt,
+            blockIds: [job.blockId],
+            threadIds: block?.threadId ? [block.threadId] : [],
+            blockDetails: block ? [{
+              id: block.id, sequence: block.sequence, title: block.l0Title ?? null,
+              threadId: block.threadId ?? null, turnRange: [block.startTurn, block.endTurn],
+            }] : [],
+            sequence: block?.sequence ?? null,
+            turnRange: block ? [block.startTurn, block.endTurn] : null,
+          }
+        }),
       ...snapshot.graphProjectionJobs
         .filter(({ status }) => status === 'failed')
-        .map((job) => ({
-          id: job.id,
-          kind: 'graph-projection',
-          attempts: job.attempts,
-          lastError: job.lastError?.slice(0, 500) ?? null,
-          lastErrorFull: job.lastError,
-          updatedAt: job.updatedAt,
-        })),
+        .map((job) => {
+          const blockIds = [...new Set(job.sourceEventIds.flatMap((eventId) =>
+            snapshot.events.find(({ id }) => id === eventId)?.sourceBlockId ?? []))]
+          const blocks = blockIds.flatMap((blockId) => snapshot.blocks.find(({ id }) => id === blockId) ?? [])
+          return {
+            id: job.id,
+            kind: 'graph-projection',
+            attempts: job.attempts,
+            nextRetryAt: null,
+            lastError: job.lastError?.slice(0, 500) ?? null,
+            lastErrorFull: job.lastError,
+            updatedAt: job.updatedAt,
+            blockIds,
+            threadIds: [...new Set(blocks.flatMap(({ threadId }) => threadId ?? []))],
+            blockDetails: blocks.map((block) => ({
+              id: block.id, sequence: block.sequence, title: block.l0Title ?? null,
+              threadId: block.threadId ?? null, turnRange: [block.startTurn, block.endTurn],
+            })),
+            sequences: blocks.map(({ sequence }) => sequence),
+            sourceEventIds: job.sourceEventIds,
+          }
+        }),
     ]
     const timestamps = [
       ...snapshot.blocks.map(({ createdAt }) => createdAt),
@@ -662,11 +712,15 @@ async function memories(runtime: StrataGateRuntime, url: URL): Promise<unknown> 
       const failedProjection = projections.find(({ status }) => status === 'failed')
       const pendingProjection = projections.some(({ status }) => status === 'pending' || status === 'running')
       const needsExtraction = source.shouldExtract === true
-      const status = extraction?.status === 'failed' || failedProjection
+      const status = summary?.status === 'failed'
         ? 'failed'
-        : extraction?.status === 'succeeded' || extraction?.status === 'skipped'
-          ? pendingProjection ? 'processing' : 'organized'
-          : needsExtraction ? 'waiting' : 'organized'
+        : summary?.status === 'pending' || summary?.status === 'running' || (!summary && source.processingStatus === 'pending')
+          ? 'processing'
+          : extraction?.status === 'failed' || failedProjection
+            ? 'failed'
+            : extraction?.status === 'succeeded' || extraction?.status === 'skipped'
+              ? pendingProjection ? 'processing' : 'organized'
+              : needsExtraction ? 'waiting' : 'organized'
       const blockPosition = scopedBlocks.findIndex(({ id }) => id === block.id) + 1
       const latestBlockPosition = scopedBlocks.length
       const currentLevel = getDecayedBlockLevel(
@@ -842,6 +896,48 @@ async function expandBlock(runtime: StrataGateRuntime, url: URL): Promise<unknow
   return runtime.adminExpandBlock(namespace, blockId, target)
 }
 
+async function retryBlockSummary(runtime: StrataGateRuntime, url: URL): Promise<unknown> {
+  const namespace = url.searchParams.get('namespace')?.trim() ?? ''
+  const blockId = url.searchParams.get('blockId')?.trim() ?? ''
+  if (!namespace) throw new AdminHttpError(400, 'namespace is required')
+  if (!blockId) throw new AdminHttpError(400, 'blockId is required')
+  if (blockId.startsWith('virtual:')) throw new AdminHttpError(409, 'Recovered legacy fragments cannot be retried')
+  const snapshot = await requiredSnapshot(runtime, namespace)
+  const job = snapshot.summaryJobs.find(({ blockId: candidateId }) => candidateId === blockId)
+  if (!job) throw new AdminHttpError(404, `Unknown Block Summary job: ${blockId}`)
+  if (job.status !== 'failed') throw new AdminHttpError(409, `Block Summary is ${job.status}, not failed`)
+  return runtime.adminRetryBlockSummary(namespace, blockId)
+}
+
+async function retryJob(runtime: StrataGateRuntime, url: URL): Promise<unknown> {
+  const namespace = url.searchParams.get('namespace')?.trim() ?? ''
+  const kind = url.searchParams.get('kind')?.trim() ?? ''
+  const jobId = url.searchParams.get('jobId')?.trim() ?? ''
+  if (!namespace) throw new AdminHttpError(400, 'namespace is required')
+  if (!['block-summary', 'event-extraction', 'graph-projection'].includes(kind)) {
+    throw new AdminHttpError(400, 'kind must be block-summary, event-extraction, or graph-projection')
+  }
+  if (!jobId) throw new AdminHttpError(400, 'jobId is required')
+  if (jobId.startsWith('virtual:')) throw new AdminHttpError(409, 'Recovered legacy fragments cannot be retried')
+  const snapshot = await requiredSnapshot(runtime, namespace)
+  const job = kind === 'block-summary'
+    ? snapshot.summaryJobs.find(({ blockId }) => blockId === jobId)
+    : kind === 'event-extraction'
+      ? snapshot.extractionJobs.find(({ blockId }) => blockId === jobId)
+      : snapshot.graphProjectionJobs.find(({ id }) => id === jobId)
+  if (!job) throw new AdminHttpError(404, `Unknown ${kind} job: ${jobId}`)
+  if (job.status !== 'failed') throw new AdminHttpError(409, `${kind} job is ${job.status}, not failed`)
+  try {
+    return await runtime.adminRetryJob(
+      namespace,
+      kind as 'block-summary' | 'event-extraction' | 'graph-projection',
+      jobId,
+    )
+  } catch (error) {
+    throw new AdminHttpError(422, error instanceof Error ? error.message : String(error))
+  }
+}
+
 function receiptSources(snapshot: StrataGateSnapshot, receipt: UsageReceipt): unknown {
   const events = snapshot.events.filter(({ id }) => receipt.eventIds.includes(id))
   const elements = snapshot.elements.filter(({ id }) => receipt.elementIds.includes(id))
@@ -968,6 +1064,12 @@ export async function handleAdminRequest(runtime: StrataGateRuntime, req: WebReq
     } else if (path === '/api/stratagate/blocks/expand') {
       if (req.method !== 'PATCH') throw new AdminHttpError(405, 'StrataGate Block expansion requires PATCH')
       sendJson(res, 200, await expandBlock(runtime, url))
+    } else if (path === '/api/stratagate/blocks/retry-summary') {
+      if (req.method !== 'POST') throw new AdminHttpError(405, 'StrataGate Block Summary retry requires POST')
+      sendJson(res, 200, await retryBlockSummary(runtime, url))
+    } else if (path === '/api/stratagate/jobs/retry') {
+      if (req.method !== 'POST') throw new AdminHttpError(405, 'StrataGate job retry requires POST')
+      sendJson(res, 200, await retryJob(runtime, url))
     } else if (path === '/api/stratagate/import') {
       if (req.method === 'GET') {
         const operation = url.searchParams.get('operation')

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -66,10 +66,10 @@ describe('StrataGate Web client contract', () => {
     expect(typeof registration.render).toBe('function')
   })
 
-  it('declares the DSH 0.1.2 Conversation package and service contracts', () => {
+  it('declares the supported DSH Conversation package and service contracts', () => {
     const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
     expect(manifest.dsh.client.inject).toEqual(['@deepseek-ai/dsh-client-ui-conversation'])
-    expect(manifest.dshWorkshop.compatibility.dshVersions).toEqual(['0.1.2-rc.1'])
+    expect(manifest.dshWorkshop.compatibility.dshVersions).toEqual(['0.1.2-rc.1', '0.1.5-rc.1'])
   })
 
   it('parses and consumes only the StrataGate feedback deep link while preserving unrelated URL state', () => {
@@ -1022,7 +1022,7 @@ describe('StrataGate Web client contract', () => {
     expect(source).toContain('lastErrorFull')
     expect(source).toContain('原始内容已经保存，不会丢失。')
     expect(source).toContain('原始记忆已保存，不会丢失。')
-    expect(source).toContain('技术错误详情')
+    expect(source).toContain('最近一次错误')
     expect(source).toContain("['raw', '{}', '原始数据'")
     expect(source).toContain("['audit', '↗', '使用记录'")
     expect(source).toContain("['settings', '⚙', '高级设置'")
@@ -1061,5 +1061,24 @@ describe('StrataGate Web client contract', () => {
     expect(source).toContain('pollFast ? 2500 : 30000')
     expect(source).not.toContain('window.setInterval')
     expect(source).toContain("status === 'waiting'")
+  })
+
+  it('separates status refresh from per-job retry with explicit feedback', () => {
+    const source = readFileSync(new URL('../src/client.js', import.meta.url), 'utf8')
+    const statusSource = source.slice(source.indexOf('function processingFingerprint'), source.indexOf('function ImportPage'))
+    expect(statusSource).toContain("api('jobs/retry'")
+    expect(statusSource).toContain("{ method: 'POST' }")
+    expect(statusSource).toContain('重试此任务')
+    expect(statusSource).toContain('正在处理…')
+    expect(statusSource).toContain('当前尝试次数')
+    expect(statusSource).toContain('最近一次错误')
+    expect(statusSource).toContain('下次重试时间')
+    expect(statusSource).toContain('只读取最新状态，不会触发模型调用。')
+    expect(statusSource).toContain('正在读取…')
+    expect(statusSource).toContain('状态已更新')
+    expect(statusSource).toContain('状态没有变化')
+    expect(statusSource).toContain('读取失败：')
+    expect(statusSource).toContain('failures.map((job) =>')
+    expect(statusSource).not.toContain('failures[0]')
   })
 })

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -12,7 +12,7 @@ describe('DeepSeek Harness plugin config', () => {
       blockDecayLambda: 0.3,
       ingestSubagents: false,
       maxOutputTokens: 2048,
-      structuredTaskTimeoutMs: 45000,
+      structuredTaskTimeoutMs: 120000,
       structuredReasoningEffort: 'auto',
       showShortTermStatus: true,
     })

--- a/tests/dsh-compatibility.test.ts
+++ b/tests/dsh-compatibility.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDshReplaceSurfaceOp,
+  classifyDshRuntime,
+  type DshRuntimePackageVersions,
+} from '../src/dsh-compatibility.js'
+
+const common = {
+  '@deepseek-ai/cordis': '4.0.2',
+  '@deepseek-ai/schemastery': '3.18.2',
+} as const
+
+function versions(version: '0.1.2-rc.1' | '0.1.5-rc.2'): DshRuntimePackageVersions {
+  return {
+    ...common,
+    '@deepseek-ai/dsh-agent-default-model': version,
+    '@deepseek-ai/dsh-client-ui-conversation': version,
+    '@deepseek-ai/dsh-llm': version,
+    '@deepseek-ai/dsh-session': version,
+    '@deepseek-ai/dsh-settings': version,
+    '@deepseek-ai/dsh-system-prompt': version,
+    '@deepseek-ai/dsh-tools': version,
+  }
+}
+
+describe('DSH runtime compatibility', () => {
+  it('accepts the complete 0.1.2 host family', () => {
+    expect(classifyDshRuntime(versions('0.1.2-rc.1')).cliVersion).toBe('0.1.2-rc.1')
+  })
+
+  it('accepts the real 0.1.5-rc.1 dependency tree at rc.2', () => {
+    expect(classifyDshRuntime(versions('0.1.5-rc.2')).cliVersion).toBe('0.1.5-rc.1')
+  })
+
+  it('rejects a mixed profile-local DSH runtime with a clear diagnostic', () => {
+    const mixed = { ...versions('0.1.5-rc.2'), '@deepseek-ai/dsh-session': '0.1.2-rc.1' }
+    expect(() => classifyDshRuntime(mixed)).toThrow(/unsupported or mixed core runtime/)
+    expect(() => classifyDshRuntime(mixed)).toThrow(/dsh-session@0\.1\.2-rc\.1/)
+  })
+
+  it('uses each host version\'s native surface replacement shape', () => {
+    expect(buildDshReplaceSurfaceOp('0.1.2-rc.1', 2, 5)).toEqual({ op: 'replace', start: 2, end: 5 })
+    expect(buildDshReplaceSurfaceOp('0.1.5-rc.2', 2, 5)).toEqual({ op: 'replace', startSeq: 2, endSeq: 5 })
+  })
+})

--- a/tests/fixtures/clean-session-v0/README.md
+++ b/tests/fixtures/clean-session-v0/README.md
@@ -1,0 +1,5 @@
+# Redacted clean DSH v0 fixture
+
+This control session has the same released v0 envelope family as the affected
+fixture but contains no StrataGate custom event. It is used for host-level
+session-list and switching tests.

--- a/tests/fixtures/clean-session-v0/session.jsonl
+++ b/tests/fixtures/clean-session-v0/session.jsonl
@@ -1,0 +1,8 @@
+{"type":"session","version":0,"id":"fixture-clean-session","createdAt":1700001000000,"cwd":"C:\\redacted\\workspace","delegationDepth":0}
+{"type":"turn/start","seq":0,"time":1700001000001,"data":{"turn":1}}
+{"type":"step/start","seq":1,"time":1700001000002,"data":{"turn":1,"step":1}}
+{"type":"user/message","seq":2,"time":1700001000003,"data":{"content":[{"type":"text","text":"Clean session user message"}],"source":{"kind":"user"},"role":"user","id":"10000000-0000-4000-8000-000000000001"},"surfaceOp":"append"}
+{"type":"assistant/message","seq":3,"time":1700001000004,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[{"type":"text","text":"Clean session assistant reply"}],"source":{"kind":"model","provider":"fixture","model":"fixture-model"},"id":"10000000-0000-4000-8000-000000000002"}},"surfaceOp":"append"}
+{"type":"step/end","seq":4,"time":1700001000005,"data":{"turn":1,"step":1}}
+{"type":"turn/end","seq":5,"time":1700001000006,"data":{"turn":1,"reason":{"kind":"completed"}}}
+{"type":"session/title","seq":6,"time":1700001000007,"data":{"title":"Clean fixture session","messageSeqs":[],"source":{"kind":"user"}},"ignorable":true}

--- a/tests/fixtures/legacy-session-v0/README.md
+++ b/tests/fixtures/legacy-session-v0/README.md
@@ -1,0 +1,7 @@
+# Redacted DSH v0 fixture
+
+This fixture preserves the envelope and event ordering of the affected legacy
+sessions while replacing every workspace path, message, identifier, model name,
+and citation value with deterministic test data. It intentionally places the
+retired `stratagate/memory-citations` event between two complete turns so tests
+can prove that content before and after the event survives migration unchanged.

--- a/tests/fixtures/legacy-session-v0/session.jsonl
+++ b/tests/fixtures/legacy-session-v0/session.jsonl
@@ -1,0 +1,15 @@
+{"type":"session","version":0,"id":"fixture-legacy-citations","createdAt":1700000000000,"cwd":"C:\\redacted\\workspace","delegationDepth":0}
+{"type":"turn/start","seq":0,"time":1700000000001,"data":{"turn":1}}
+{"type":"step/start","seq":1,"time":1700000000002,"data":{"turn":1,"step":1}}
+{"type":"user/message","seq":2,"time":1700000000003,"data":{"content":[{"type":"text","text":"Redacted user message A"}],"source":{"kind":"user"},"role":"user","id":"00000000-0000-4000-8000-000000000001"},"surfaceOp":"append"}
+{"type":"assistant/message","seq":3,"time":1700000000004,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[{"type":"text","text":"Redacted assistant reply A"}],"source":{"kind":"model","provider":"fixture","model":"fixture-model"},"id":"00000000-0000-4000-8000-000000000002"}},"surfaceOp":"append"}
+{"type":"step/end","seq":4,"time":1700000000005,"data":{"turn":1,"step":1}}
+{"type":"turn/end","seq":5,"time":1700000000006,"data":{"turn":1,"reason":{"kind":"completed"}}}
+{"type":"stratagate/memory-citations","seq":6,"time":1700000000007,"data":{"citations":[{"id":"redacted-memory-id","title":"Redacted citation"}]},"ignorable":true}
+{"type":"turn/start","seq":7,"time":1700000000008,"data":{"turn":2}}
+{"type":"step/start","seq":8,"time":1700000000009,"data":{"turn":2,"step":1}}
+{"type":"user/message","seq":9,"time":1700000000010,"data":{"content":[{"type":"text","text":"Redacted user message B"}],"source":{"kind":"user"},"role":"user","id":"00000000-0000-4000-8000-000000000003"},"surfaceOp":"append"}
+{"type":"assistant/message","seq":10,"time":1700000000011,"data":{"turn":2,"step":1,"message":{"role":"assistant","content":[{"type":"text","text":"Redacted assistant reply B"}],"source":{"kind":"model","provider":"fixture","model":"fixture-model"},"id":"00000000-0000-4000-8000-000000000004"}},"surfaceOp":"append"}
+{"type":"step/end","seq":11,"time":1700000000012,"data":{"turn":2,"step":1}}
+{"type":"turn/end","seq":12,"time":1700000000013,"data":{"turn":2,"reason":{"kind":"completed"}}}
+{"type":"session/title","seq":13,"time":1700000000014,"data":{"title":"Legacy citation fixture","messageSeqs":[],"source":{"kind":"user"}},"ignorable":true}

--- a/tests/legacy-session.test.ts
+++ b/tests/legacy-session.test.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as zlib from 'node:zlib'
+import { describe, expect, it } from 'vitest'
+import { releasedV0SessionFormatCodec, releasedV1SessionFormatCodec, sessionFormatV0ToV1 } from '@deepseek-ai/dsh-session-format-v0-to-v1'
+import { sessionFormatCatalog } from '@deepseek-ai/dsh-session-format-catalog'
+import {
+  migrateLegacyCitationSessions,
+  prepareLegacyCitationGeneration,
+  scanZstdFrames,
+} from '../src/legacy-session.js'
+
+const fixturePath = join(import.meta.dirname, 'fixtures', 'legacy-session-v0', 'session.jsonl')
+const modules = {
+  releasedV0SessionFormatCodec,
+  releasedV1SessionFormatCodec,
+  sessionFormatV0ToV1,
+  sessionFormatCatalog,
+}
+
+function digest(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+function conversationText(events: readonly any[]): string[] {
+  return events.flatMap((event) => {
+    if (event.type === 'user/message') return event.data.content.map((block: any) => block.text).filter(Boolean)
+    if (event.type === 'assistant/message') return event.data.message.content.map((block: any) => block.text).filter(Boolean)
+    return []
+  })
+}
+
+describe('legacy stratagate/memory-citations migration', () => {
+  it('uses the official v0-to-v3 catalog without changing conversation content', async () => {
+    const source = await readFile(fixturePath)
+    const originalHash = digest(source)
+    const prepared = prepareLegacyCitationGeneration(source, 'none', modules)
+    expect(prepared).toBeDefined()
+    expect(digest(source)).toBe(originalHash)
+    expect(prepared!.citationSeqs).toEqual([6])
+    expect(conversationText(prepared!.currentEvents)).toEqual([
+      'Redacted user message A',
+      'Redacted assistant reply A',
+      'Redacted user message B',
+      'Redacted assistant reply B',
+    ])
+    expect(prepared!.currentEvents.some((event) => event.type === 'stratagate/memory-citations')).toBe(false)
+    expect(prepared!.currentEvents.some((event) => event.type === 'feedback/record')).toBe(true)
+  })
+
+  it('refuses to reinterpret a non-ignorable or surface-participating citation event', async () => {
+    const source = await readFile(fixturePath, 'utf8')
+    const unsafe = Buffer.from(source.replace('"ignorable":true', '"ignorable":false'))
+    expect(() => prepareLegacyCitationGeneration(unsafe, 'none', modules)).toThrow(/not marked ignorable/)
+  })
+
+  it('publishes an atomic v1 bridge and a recovery receipt while leaving v0 untouched', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'stratagate-session-migration-'))
+    const directory = join(root, 'redacted-project', 'fixture-session')
+    await mkdir(directory, { recursive: true })
+    const source = await readFile(fixturePath)
+    const sourcePath = join(directory, 'session.jsonl')
+    await writeFile(sourcePath, source)
+    const before = digest(await readFile(sourcePath))
+
+    const result = await migrateLegacyCitationSessions(root)
+    expect(result).toEqual({ scanned: 1, migrated: 1, skipped: 0, failures: [] })
+    expect(digest(await readFile(sourcePath))).toBe(before)
+    const target = await readFile(join(directory, 'session.v1.jsonl'), 'utf8')
+    expect(target).toContain('"version":1')
+    expect(target).toContain('"type":"feedback/record"')
+    expect(target).not.toContain('stratagate/memory-citations')
+    const receipt = JSON.parse(await readFile(join(directory, 'stratagate-legacy-citations-v1.json'), 'utf8'))
+    expect(receipt.sourceSha256).toBe(before)
+    expect(receipt.targetSha256).toBe(digest(Buffer.from(target)))
+    expect(receipt.recovery).toContain('unchanged session.jsonl')
+
+    expect(await migrateLegacyCitationSessions(root)).toEqual({ scanned: 1, migrated: 0, skipped: 1, failures: [] })
+  })
+
+  it('preserves concatenated zstd generations and validates every frame', async () => {
+    const source = await readFile(fixturePath)
+    const newline = source.indexOf(10) + 1
+    const options = { params: { [zlib.constants.ZSTD_c_checksumFlag]: 1 } }
+    const compressed = Buffer.concat([
+      zlib.zstdCompressSync(source.subarray(0, newline), options),
+      zlib.zstdCompressSync(source.subarray(newline), options),
+    ])
+    expect(scanZstdFrames(compressed)).toHaveLength(2)
+    const prepared = prepareLegacyCitationGeneration(compressed, 'zstd', modules)
+    expect(prepared).toBeDefined()
+    expect(scanZstdFrames(prepared!.bytes)).toHaveLength(2)
+    expect(conversationText(prepared!.currentEvents)).toHaveLength(4)
+  })
+})

--- a/tests/legacy-session.test.ts
+++ b/tests/legacy-session.test.ts
@@ -20,6 +20,12 @@ const modules = {
   sessionFormatCatalog,
 }
 
+function platformFixture(source: Buffer): Buffer {
+  const cwd = process.platform === 'win32' ? 'C:\\redacted\\workspace' : '/redacted/workspace'
+  const text = source.toString('utf8').replace(/("cwd":)"[^"]*"/, `$1${JSON.stringify(cwd)}`)
+  return Buffer.from(text)
+}
+
 function digest(bytes: Uint8Array): string {
   return createHash('sha256').update(bytes).digest('hex')
 }
@@ -34,7 +40,7 @@ function conversationText(events: readonly any[]): string[] {
 
 describe('legacy stratagate/memory-citations migration', () => {
   it('uses the official v0-to-v3 catalog without changing conversation content', async () => {
-    const source = await readFile(fixturePath)
+    const source = platformFixture(await readFile(fixturePath))
     const originalHash = digest(source)
     const prepared = prepareLegacyCitationGeneration(source, 'none', modules)
     expect(prepared).toBeDefined()
@@ -51,8 +57,8 @@ describe('legacy stratagate/memory-citations migration', () => {
   })
 
   it('refuses to reinterpret a non-ignorable or surface-participating citation event', async () => {
-    const source = await readFile(fixturePath, 'utf8')
-    const unsafe = Buffer.from(source.replace('"ignorable":true', '"ignorable":false'))
+    const source = platformFixture(await readFile(fixturePath))
+    const unsafe = Buffer.from(source.toString('utf8').replace('"ignorable":true', '"ignorable":false'))
     expect(() => prepareLegacyCitationGeneration(unsafe, 'none', modules)).toThrow(/not marked ignorable/)
   })
 
@@ -60,7 +66,7 @@ describe('legacy stratagate/memory-citations migration', () => {
     const root = await mkdtemp(join(tmpdir(), 'stratagate-session-migration-'))
     const directory = join(root, 'redacted-project', 'fixture-session')
     await mkdir(directory, { recursive: true })
-    const source = await readFile(fixturePath)
+    const source = platformFixture(await readFile(fixturePath))
     const sourcePath = join(directory, 'session.jsonl')
     await writeFile(sourcePath, source)
     const before = digest(await readFile(sourcePath))
@@ -81,7 +87,7 @@ describe('legacy stratagate/memory-citations migration', () => {
   })
 
   it('preserves concatenated zstd generations and validates every frame', async () => {
-    const source = await readFile(fixturePath)
+    const source = platformFixture(await readFile(fixturePath))
     const newline = source.indexOf(10) + 1
     const options = { params: { [zlib.constants.ZSTD_c_checksumFlag]: 1 } }
     const compressed = Buffer.concat([

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -231,6 +231,95 @@ describe('DSH runtime ingestion', () => {
     }
   })
 
+  it('retries one terminally failed Block Summary from the admin surface', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'stratagate-summary-retry-'))
+    const database = join(directory, 'memory.db')
+    let shouldFail = true
+    let summaryCalls = 0
+    const models = {
+      ...fakeModels,
+      summarizer: async () => {
+        summaryCalls += 1
+        if (shouldFail) throw new Error('invalid API key')
+        return { l0Title: 'retried', l0Tags: [], l1Summary: 'retried', l2Keypoints: [], shouldExtract: false }
+      },
+    } as unknown as DshModelBridge
+    const runtime = new StrataGateRuntime({
+      database, namespaceMode: 'project', namespacePrefix: 'dsh', globalNamespace: 'global',
+      blockTurnSize: 1, blockDecayLambda: 0.3, ingestSubagents: false, maxOutputTokens: 2048,
+    }, models)
+    try {
+      const memory = await (runtime as unknown as { space: (value: Session) => Promise<StrataGate> }).space(session)
+      await memory.appendTurn({ user: 'retry this summary', assistant: 'saved', threadId: String(session.id) })
+      await memory.resumePendingWork({ retryFailed: true })
+      await memory.resumePendingWork({ retryFailed: true })
+      const block = memory.listBlocks()[0]!
+      expect(memory.listSummaryJobs()[0]).toMatchObject({ status: 'failed', attempts: 3, nextRetryAt: null })
+
+      shouldFail = false
+      const [result, duplicate] = await Promise.all([
+        runtime.adminRetryBlockSummary(runtime.namespaceFor(session), block.id),
+        runtime.adminRetryBlockSummary(runtime.namespaceFor(session), block.id),
+      ]) as Array<{
+        ready: boolean; processingStatus: string; summaryJob: { status: string; attempts: number }
+      }>
+      expect(result).toMatchObject({
+        ready: true,
+        processingStatus: 'ready',
+        summaryJob: { status: 'succeeded', attempts: 1 },
+      })
+      expect(duplicate).toEqual(result)
+      expect(summaryCalls).toBe(4)
+      expect(memory.listExtractionJobs()[0]).toMatchObject({ blockId: block.id, status: 'skipped' })
+    } finally {
+      await runtime.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('retries Event extraction without rerunning a successful Summary', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'stratagate-extraction-retry-'))
+    const database = join(directory, 'memory.db')
+    let shouldFail = true
+    let summaryCalls = 0
+    let extractionCalls = 0
+    const models = {
+      ...fakeModels,
+      summarizer: async () => {
+        summaryCalls += 1
+        return { l0Title: 'event', l0Tags: [], l1Summary: 'event', l2Keypoints: [], shouldExtract: true }
+      },
+      extractor: async () => {
+        extractionCalls += 1
+        if (shouldFail) throw new Error('StrataGate structured model task timed out after 45000ms')
+        return { shouldExtract: false, reason: 'nothing durable', events: [] }
+      },
+    } as unknown as DshModelBridge
+    const runtime = new StrataGateRuntime({
+      database, namespaceMode: 'project', namespacePrefix: 'dsh', globalNamespace: 'global',
+      blockTurnSize: 1, blockDecayLambda: 0.3, ingestSubagents: false, maxOutputTokens: 2048,
+    }, models)
+    try {
+      const memory = await (runtime as unknown as { space: (value: Session) => Promise<StrataGate> }).space(session)
+      await memory.appendTurn({ user: 'retry extraction', assistant: 'saved', threadId: String(session.id) })
+      await memory.resumePendingWork({ retryFailed: true })
+      await memory.resumePendingWork({ retryFailed: true })
+      const block = memory.listBlocks()[0]!
+      expect(memory.listExtractionJobs()[0]).toMatchObject({ status: 'failed', attempts: 3, nextRetryAt: null })
+
+      shouldFail = false
+      const result = await runtime.adminRetryJob(runtime.namespaceFor(session), 'event-extraction', block.id) as {
+        kind: string; status: string; ready: boolean
+      }
+      expect(result).toMatchObject({ kind: 'event-extraction', status: 'skipped', ready: true })
+      expect(summaryCalls).toBe(1)
+      expect(extractionCalls).toBe(4)
+    } finally {
+      await runtime.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it('returns compact event/graph/raw cards while expand preserves full details', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'stratagate-dsh-compact-search-'))
     const database = join(directory, 'memory.db')
@@ -857,17 +946,17 @@ describe('DSH runtime ingestion', () => {
     }
     const appendPlainTurn = (turn: number, user: string, assistant: string): void => {
       append('turn/start', { turn })
+      append('step/start', { turn, step: 1 })
       append('user/message', createUserMessage({
         content: [{ type: 'text', text: user }], source: { kind: 'user' },
       }), { surfaceOp: 'append' })
-      append('step/start', { turn, step: 1 })
       append('assistant/message', {
         turn, step: 1,
         message: createAssistantMessage({
           content: [{ type: 'text', text: assistant }],
           source: { provider: 'test', model: 'test' },
         }),
-      }, { surfaceOp: 'append', sourceEventSeqs: [] })
+      }, { surfaceOp: 'append' })
       append('step/end', { turn, step: 1 })
       append('turn/end', { turn, reason: { kind: 'completed' } })
     }
@@ -903,17 +992,17 @@ describe('DSH runtime ingestion', () => {
 
       const callId = 'current-tool-call' as never
       append('turn/start', { turn: 3 })
+      append('step/start', { turn: 3, step: 1 })
       append('user/message', createUserMessage({
         content: [{ type: 'text', text: 'CURRENT USER SENTINEL' }], source: { kind: 'user' },
       }), { surfaceOp: 'append' })
-      append('step/start', { turn: 3, step: 1 })
       append('assistant/message', {
         turn: 3, step: 1,
         message: createAssistantMessage({
           content: [{ type: 'tool-call', id: callId, name: 'inspect_workspace', arguments: '{"path":"CURRENT_TOOL_PATH"}' }],
           source: { provider: 'test', model: 'test' },
         }),
-      }, { surfaceOp: 'append', sourceEventSeqs: [] })
+      }, { surfaceOp: 'append' })
       append('tool/call', { turn: 3, step: 1, callId, name: 'inspect_workspace', arguments: '{"path":"CURRENT_TOOL_PATH"}' })
       append('tool/result', {
         turn: 3, step: 1,
@@ -931,7 +1020,7 @@ describe('DSH runtime ingestion', () => {
           content: [{ type: 'text', text: 'CURRENT FINAL ANSWER' }],
           source: { provider: 'test', model: 'test' },
         }),
-      }, { surfaceOp: 'append', sourceEventSeqs: [] })
+      }, { surfaceOp: 'append' })
       append('step/end', { turn: 3, step: 2 })
       append('turn/end', { turn: 3, reason: { kind: 'completed' } })
       await runtime.flush()

--- a/tests/web.test.ts
+++ b/tests/web.test.ts
@@ -243,6 +243,163 @@ describe('StrataGate admin routes', () => {
     expect(skipped.body.items[0]).toMatchObject({ status: 'organized', eventExtraction: null })
   })
 
+  it('reports Summary jobs in overview and Block processing state', async () => {
+    const pendingBlock = {
+      ...snapshot.blocks[0]!,
+      processingStatus: 'pending' as const,
+      shouldExtract: undefined,
+      l0Title: undefined,
+      l0Tags: undefined,
+      l1Summary: undefined,
+      l2Keypoints: undefined,
+    }
+    const summaryFailure = 'Summary model timed out'
+    let retriedBlock: { namespace: string; blockId: string } | null = null
+    const summaryRuntime = {
+      adminNamespaces: async () => ['dsh:project:summary'],
+      adminSnapshot: async () => ({
+        ...snapshot,
+        blocks: [pendingBlock],
+        summaryJobs: [{
+          blockId: 'blk_1', status: 'failed' as const, attempts: 3, lastError: summaryFailure,
+          nextRetryAt: null, updatedAt: '2026-08-18T00:03:00.000Z',
+        }],
+        extractionJobs: [],
+        graphProjectionJobs: [],
+      }),
+      adminWorkspaceName: () => 'Summary workspace',
+      adminRetryBlockSummary: async (namespace: string, blockId: string) => {
+        retriedBlock = { namespace, blockId }
+        return { blockId, ready: true, processingStatus: 'ready', summaryJob: { status: 'succeeded' } }
+      },
+    } as unknown as StrataGateRuntime
+
+    const overview = await request('/api/stratagate/overview', 'GET', summaryRuntime)
+    expect(overview.body.namespaces[0]).toMatchObject({
+      failedJobs: 1,
+      processingJobs: 0,
+      failedJobDetails: [{
+        id: 'blk_1', kind: 'block-summary', attempts: 3,
+        lastError: summaryFailure, lastErrorFull: summaryFailure,
+      }],
+    })
+
+    const failed = await request('/api/stratagate/memories?namespace=dsh%3Aproject%3Asummary&kind=blocks', 'GET', summaryRuntime)
+    expect(failed.body.items[0]).toMatchObject({ status: 'failed', processingStatus: 'pending', summaryJob: { status: 'failed' } })
+
+    const retried = await request('/api/stratagate/blocks/retry-summary?namespace=dsh%3Aproject%3Asummary&blockId=blk_1', 'POST', summaryRuntime)
+    expect(retried).toMatchObject({ status: 200, body: { blockId: 'blk_1', ready: true, summaryJob: { status: 'succeeded' } } })
+    expect(retriedBlock).toEqual({ namespace: 'dsh:project:summary', blockId: 'blk_1' })
+
+    const runningRuntime = {
+      ...summaryRuntime,
+      adminSnapshot: async () => ({
+        ...snapshot,
+        blocks: [pendingBlock],
+        summaryJobs: [{
+          blockId: 'blk_1', status: 'running' as const, attempts: 1, lastError: null,
+          nextRetryAt: null, updatedAt: '2026-08-18T00:03:00.000Z',
+        }],
+        extractionJobs: [],
+        graphProjectionJobs: [],
+      }),
+    } as unknown as StrataGateRuntime
+    const running = await request('/api/stratagate/memories?namespace=dsh%3Aproject%3Asummary&kind=blocks', 'GET', runningRuntime)
+    expect(running.body.items[0]).toMatchObject({ status: 'processing', processingStatus: 'pending', summaryJob: { status: 'running' } })
+
+    const extractionFailureRuntime = {
+      ...summaryRuntime,
+      adminSnapshot: async () => ({
+        ...snapshot,
+        blocks: [{ ...pendingBlock, shouldExtract: true }],
+        summaryJobs: [{
+          blockId: 'blk_1', status: 'succeeded' as const, attempts: 1, lastError: null,
+          nextRetryAt: null, updatedAt: '2026-08-18T00:03:00.000Z',
+        }],
+        extractionJobs: [{
+          blockId: 'blk_1', status: 'failed' as const, attempts: 3, lastError: 'Extraction failed',
+          nextRetryAt: null, updatedAt: '2026-08-18T00:04:00.000Z',
+        }],
+        graphProjectionJobs: [],
+      }),
+    } as unknown as StrataGateRuntime
+    const extractionFailure = await request('/api/stratagate/memories?namespace=dsh%3Aproject%3Asummary&kind=blocks', 'GET', extractionFailureRuntime)
+    expect(extractionFailure.body.items[0]).toMatchObject({ status: 'failed', processingStatus: 'pending', summaryJob: { status: 'succeeded' } })
+  })
+
+  it('rejects Block Summary retries while the job is not failed', async () => {
+    const retryingRuntime = {
+      adminSnapshot: async () => ({
+        ...snapshot,
+        summaryJobs: [{
+          blockId: 'blk_1', status: 'running' as const, attempts: 1, lastError: null,
+          nextRetryAt: null, updatedAt: '2026-08-18T00:04:00.000Z',
+        }],
+      }),
+    } as unknown as StrataGateRuntime
+    const result = await request('/api/stratagate/blocks/retry-summary?namespace=dsh%3Aproject%3Asummary&blockId=blk_1', 'POST', retryingRuntime)
+    expect(result).toMatchObject({ status: 409, body: { error: 'Block Summary is running, not failed' } })
+  })
+
+  it('retries a specific failed job through the unified endpoint and reports model failures', async () => {
+    const calls: Array<{ namespace: string; kind: string; jobId: string }> = []
+    const failedSnapshot = {
+      ...snapshot,
+      blocks: [{ ...snapshot.blocks[0]!, processingStatus: 'pending' as const, threadId: 'thread-retry' }],
+      summaryJobs: [],
+      extractionJobs: [{
+        blockId: 'blk_1', status: 'failed' as const, attempts: 3,
+        lastError: 'StrataGate structured model task timed out after 45000ms', nextRetryAt: null,
+        updatedAt: '2026-08-18T00:04:00.000Z',
+      }],
+      graphProjectionJobs: [{
+        ...snapshot.graphProjectionJobs[0]!, id: 'gproj_failed', status: 'failed' as const,
+        attempts: 2, lastError: 'graph failed', nodeIds: [],
+      }],
+    }
+    const retryRuntime = {
+      adminSnapshot: async () => failedSnapshot,
+      adminRetryJob: async (namespace: string, kind: string, jobId: string) => {
+        calls.push({ namespace, kind, jobId })
+        if (kind === 'graph-projection') throw new Error('graph timed out again')
+        return { kind, jobId, status: 'succeeded' }
+      },
+    } as unknown as StrataGateRuntime
+
+    const extraction = await request('/api/stratagate/jobs/retry?namespace=dsh%3Aproject%3Atest&kind=event-extraction&jobId=blk_1', 'POST', retryRuntime)
+    expect(extraction).toMatchObject({ status: 200, body: { kind: 'event-extraction', jobId: 'blk_1', status: 'succeeded' } })
+    const graph = await request('/api/stratagate/jobs/retry?namespace=dsh%3Aproject%3Atest&kind=graph-projection&jobId=gproj_failed', 'POST', retryRuntime)
+    expect(graph).toMatchObject({ status: 422, body: { error: 'graph timed out again' } })
+    expect(calls).toEqual([
+      { namespace: 'dsh:project:test', kind: 'event-extraction', jobId: 'blk_1' },
+      { namespace: 'dsh:project:test', kind: 'graph-projection', jobId: 'gproj_failed' },
+    ])
+
+    const running = await request('/api/stratagate/jobs/retry?namespace=dsh%3Aproject%3Atest&kind=event-extraction&jobId=blk_1', 'POST', {
+      adminSnapshot: async () => ({
+        ...failedSnapshot,
+        extractionJobs: [{ ...failedSnapshot.extractionJobs[0]!, status: 'running' as const }],
+      }),
+    } as unknown as StrataGateRuntime)
+    expect(running).toMatchObject({ status: 409, body: { error: 'event-extraction job is running, not failed' } })
+
+    const overview = await request('/api/stratagate/overview', 'GET', {
+      adminNamespaces: async () => ['dsh:project:test'],
+      adminSnapshot: async () => failedSnapshot,
+      adminWorkspaceName: () => 'Retry workspace',
+    } as unknown as StrataGateRuntime)
+    expect(overview.body.namespaces[0].failedJobDetails).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'event-extraction', id: 'blk_1', nextRetryAt: null,
+        blockIds: ['blk_1'], threadIds: ['thread-retry'], turnRange: [1, 4],
+      }),
+      expect.objectContaining({
+        kind: 'graph-projection', id: 'gproj_failed', nextRetryAt: null,
+        blockIds: ['blk_1'], threadIds: ['thread-retry'], sourceEventIds: ['evt_1'],
+      }),
+    ]))
+  })
+
   it('summarizes namespaces and returns paginated memories', async () => {
     const overview = await request('/api/stratagate/overview')
     expect(overview.status).toBe(200)

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/bootstrap.ts',
+    plugin: 'src/index.ts',
+    'repair-profile': 'src/repair-profile.ts',
+  },
   format: ['esm'],
   target: 'node22',
   dts: true,
@@ -12,5 +16,6 @@ export default defineConfig({
   noExternal: [/^@diqier\/stratagate(?:\/.*)?$/],
   external: [
     /^@deepseek-ai\//,
+    /^\.\/plugin\.js$/,
   ],
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
       { find: '@diqier/stratagate', replacement: fileURLToPath(new URL('./packages/core/src/index.ts', import.meta.url)) },
     ],
   },
-  test: { include: ['tests/**/*.test.ts'] },
+  test: {
+    include: ['tests/**/*.test.ts'],
+    testTimeout: process.env.CI ? 30_000 : 5_000,
+  },
 });


### PR DESCRIPTION
## Summary
- synchronize the 0.2.64 source, tests, compatibility support, and package metadata
- build and verify release artifacts from the checked-out main commit
- validate package and lockfile versions before publishing
- remove the staging-artifact publishing path that caused npm provenance to point at stale source

## Verification
- npm run check passes
- npm test is blocked in the current Node v22.12.0 environment because node:sqlite requires Node 22.19+ or Node 24